### PR TITLE
Writing folder searcher attempt

### DIFF
--- a/codecov_cli/helpers/folder_searcher.py
+++ b/codecov_cli/helpers/folder_searcher.py
@@ -1,0 +1,24 @@
+import os
+import pathlib
+import typing
+
+
+def search_files(
+    folder_to_search: pathlib.Path,
+    folders_to_ignore: typing.List[str],
+    filename_include_regex: typing.Pattern,
+    *,
+    filename_exclude_regex: typing.Optional[typing.Pattern],
+) -> typing.List[pathlib.Path]:
+    for (dirpath, dirnames, filenames) in os.walk(folder_to_search):
+        dirs_to_remove = set(d for d in dirnames if d in folders_to_ignore)
+        for directory in dirs_to_remove:
+            # Removing to ensure we don't even try to search those
+            # This is the documented way of doing this on python docs
+            dirnames.remove(directory)
+        for single_filename in filenames:
+            if filename_include_regex.match(single_filename) and (
+                filename_exclude_regex is None
+                or not filename_exclude_regex.match(single_filename)
+            ):
+                yield pathlib.Path(dirpath) / single_filename

--- a/tests/test_folder_searcher.py
+++ b/tests/test_folder_searcher.py
@@ -1,0 +1,107 @@
+import re
+
+from codecov_cli.helpers.folder_searcher import search_files
+
+
+def test_search_files(tmp_path):
+    search_for = re.compile("banana.*")
+    filepaths = [
+        "banana.txt",
+        "path/to/banana.c",
+        "path/to/banana.py",
+        "apple.py",
+        "banana.py",
+    ]
+    for f in filepaths:
+        relevant_filepath = tmp_path / f
+        relevant_filepath.parent.mkdir(parents=True, exist_ok=True)
+        relevant_filepath.touch()
+    expected_results = sorted(
+        [
+            tmp_path / "banana.txt",
+            tmp_path / "banana.py",
+            tmp_path / "path/to/banana.py",
+            tmp_path / "path/to/banana.c",
+        ]
+    )
+    assert expected_results == sorted(
+        search_files(tmp_path, [], search_for, filename_exclude_regex=None)
+    )
+
+
+def test_search_files_with_folder_exclusion(tmp_path):
+    search_for = re.compile("banana.*")
+    filepaths = [
+        "banana.txt",
+        "path/to/banana.c",
+        "path/to/banana.py",
+        "another/to/banana.py",
+        "another/some/banana.py",
+        "from/some/banana.py",
+        "to/some/banana.py",
+        "apple.py",
+        "banana.py",
+    ]
+    for f in filepaths:
+        relevant_filepath = tmp_path / f
+        relevant_filepath.parent.mkdir(parents=True, exist_ok=True)
+        relevant_filepath.touch()
+    expected_results = sorted(
+        [
+            tmp_path / "banana.txt",
+            tmp_path / "banana.py",
+            tmp_path / "from/some/banana.py",
+            tmp_path / "another/some/banana.py",
+        ]
+    )
+    assert expected_results == sorted(
+        search_files(tmp_path, ["to"], search_for, filename_exclude_regex=None)
+    )
+
+
+def test_search_files_combined_regex(tmp_path):
+    search_for = re.compile(r"(banana.*)|(apple\..*)")
+    filepaths = [
+        "banana.txt",
+        "path/to/banana.c",
+        "path/to/banana.py",
+        "apple.py",
+        "banana.py",
+    ]
+    for f in filepaths:
+        relevant_filepath = tmp_path / f
+        relevant_filepath.parent.mkdir(parents=True, exist_ok=True)
+        relevant_filepath.touch()
+    expected_results = sorted(
+        [
+            tmp_path / "banana.txt",
+            tmp_path / "banana.py",
+            tmp_path / "apple.py",
+            tmp_path / "path/to/banana.py",
+            tmp_path / "path/to/banana.c",
+        ]
+    )
+    assert expected_results == sorted(
+        search_files(tmp_path, [], search_for, filename_exclude_regex=None)
+    )
+
+
+def test_search_files_with_exclude_regex(tmp_path):
+    search_for = re.compile("banana.*")
+    filepaths = [
+        "banana.txt",
+        "path/to/banana.c",
+        "path/to/banana.py",
+        "apple.py",
+        "banana.py",
+    ]
+    for f in filepaths:
+        relevant_filepath = tmp_path / f
+        relevant_filepath.parent.mkdir(parents=True, exist_ok=True)
+        relevant_filepath.touch()
+    expected_results = sorted([tmp_path / "banana.txt", tmp_path / "path/to/banana.c"])
+    assert expected_results == sorted(
+        search_files(
+            tmp_path, [], search_for, filename_exclude_regex=re.compile(r".*\.py")
+        )
+    )


### PR DESCRIPTION
From what we are looking at, the main requirements for looking for files is:

- Denylists of folders (as in, don't look into `bower` folders)
- Files with simple stars

Looking into python's implementation of `fnmatch` and `glob` (which internally just calls `fnmatch` at the right places), the system just compiles the patterns into regexes and uses those.

Allied with that, it seems that there was some good effort into making `os.walk` received some effort to make it faster on Python 3.5 ( https://peps.python.org/pep-0471/#os-walk )

So, we can try to use those two elements in conjunction. It will also be interesting to take all include filename patterns and turn them into one big compiled regex (at import time, no need to manually write regexes). The regex would end up looking like `r"(banana.*)|(apple\..*)"`. The compiled version of the regex should be faster than looping through individual regexes