### PR TITLE
Implementing plugin from YAML

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,2 @@
+ignore:
+  - tests/**

--- a/codecov_cli/commands/upload.py
+++ b/codecov_cli/commands/upload.py
@@ -84,6 +84,8 @@ def do_upload(
     plugin_names: typing.List[str],
 ):
     versioning_system = ctx.obj["versioning_system"]
+    codecov_yaml = ctx.obj["codecov_yaml"] or {}
+    cli_config = codecov_yaml.get("cli", {})
     print(
         dict(
             commit_sha=commit_sha,
@@ -101,6 +103,7 @@ def do_upload(
         )
     )
     do_upload_logic(
+        cli_config,
         versioning_system,
         commit_sha=commit_sha,
         report_code=report_code,

--- a/codecov_cli/entrypoints.py
+++ b/codecov_cli/entrypoints.py
@@ -127,6 +127,7 @@ class UploadSender(object):
 
 
 def do_upload_logic(
+    cli_config: typing.Dict,
     versioning_system: VersioningSystemInterface,
     *,
     commit_sha: str,
@@ -142,7 +143,7 @@ def do_upload_logic(
     plugin_names: typing.List[str],
     token: uuid.UUID,
 ):
-    preparation_plugins = select_preparation_plugins(plugin_names)
+    preparation_plugins = select_preparation_plugins(cli_config, plugin_names)
     coverage_file_selector = select_coverage_file_finder()
     network_finder = select_network_finder(versioning_system)
     collector = UploadCollector(

--- a/codecov_cli/main.py
+++ b/codecov_cli/main.py
@@ -30,7 +30,7 @@ def cli(
 ):
     ctx.obj["ci_adapter"] = get_ci_adapter(auto_load_params_from)
     ctx.obj["versioning_system"] = get_versioning_system()
-    ctx.obj["codecov_yml"] = (
+    ctx.obj["codecov_yaml"] = (
         yaml.safe_load(codecov_yml_path.read())
         if codecov_yml_path is not None
         else None

--- a/codecov_cli/plugins/__init__.py
+++ b/codecov_cli/plugins/__init__.py
@@ -1,3 +1,8 @@
+import typing
+from importlib import import_module
+
+import click
+
 from codecov_cli.plugins.gcov import GcovPlugin
 from codecov_cli.plugins.pycoverage import Pycoverage
 
@@ -7,13 +12,35 @@ class NoopPlugin(object):
         pass
 
 
-def select_preparation_plugins(plugin_names):
-    return [_get_plugin(p) for p in plugin_names]
+def select_preparation_plugins(cli_config: typing.Dict, plugin_names: typing.List[str]):
+    return [_get_plugin(cli_config, p) for p in plugin_names]
 
 
-def _get_plugin(plugin_name):
+def _load_plugin_from_yaml(plugin_dict: typing.Dict):
+    try:
+        class_obj = import_module(plugin_dict["path"])
+    except ModuleNotFoundError:
+        click.secho(
+            f"Unable to dynamically load plugin on path {plugin_dict['path']}",
+            err=True,
+        )
+        return NoopPlugin()
+    try:
+        return class_obj(**plugin_dict["params"])
+    except TypeError:
+        click.secho(
+            f"Unable to instantiate {class_obj} with parameters {plugin_dict['params']}",
+            err=True,
+        )
+        return NoopPlugin()
+
+
+def _get_plugin(cli_config, plugin_name):
     if plugin_name == "gcov":
         return GcovPlugin()
     if plugin_name == "pycoverage":
         return Pycoverage()
+    if cli_config and plugin_name in cli_config.get("plugins", {}):
+        return _load_plugin_from_yaml(cli_config["plugins"][plugin_name])
+    click.secho(f"Unable to find plugin {plugin_name}", fg="magenta", err=True)
     return NoopPlugin()

--- a/tests/plugins/test_instantiation.py
+++ b/tests/plugins/test_instantiation.py
@@ -1,0 +1,80 @@
+from codecov_cli.plugins import (
+    GcovPlugin,
+    NoopPlugin,
+    _get_plugin,
+    _load_plugin_from_yaml,
+    select_preparation_plugins,
+)
+
+
+def test_load_plugin_from_yaml(mocker):
+    class SamplePlugin(object):
+        def __init__(self, banana, other):
+            self.something = banana
+            self.other = other
+
+    mocker.patch("codecov_cli.plugins.import_module", return_value=SamplePlugin)
+    res = _load_plugin_from_yaml(
+        {"path": "a", "params": {"banana": "super", "other": 1}}
+    )
+    assert isinstance(res, SamplePlugin)
+    assert res.something == "super"
+    assert res.other == 1
+
+
+def test_load_plugin_from_yaml_non_existing_class(mocker):
+    res = _load_plugin_from_yaml(
+        {"path": "nonexisting.path", "params": {"banana": "super", "other": 1}}
+    )
+    assert isinstance(res, NoopPlugin)
+
+
+def test_load_plugin_from_yaml_bad_parameters(mocker):
+    class SamplePlugin(object):
+        def __init__(self, banana):
+            pass
+
+    mocker.patch("codecov_cli.plugins.import_module", return_value=SamplePlugin)
+    res = _load_plugin_from_yaml(
+        {"path": "a", "params": {"banana": "super", "other": 1}}
+    )
+    assert isinstance(res, NoopPlugin)
+
+
+def test_get_plugin_gcov():
+    res = _get_plugin({}, "gcov")
+    assert isinstance(res, GcovPlugin)
+
+
+def test_select_preparation_plugins(mocker):
+    class SamplePlugin(object):
+        def __init__(self, banana=None):
+            pass
+
+    class SecondSamplePlugin(object):
+        def __init__(self, banana=None):
+            pass
+
+    mocker.patch(
+        "codecov_cli.plugins.import_module",
+        side_effect=[ModuleNotFoundError, SamplePlugin, SecondSamplePlugin],
+    )
+    res = select_preparation_plugins(
+        {
+            "plugins": {
+                "otherthing": {
+                    "path": "a",
+                    "params": {"banana": "apple", "pineapple": 2},
+                },
+                "second": {"path": "b", "params": {"banana": "apple"}},
+                "something": {"path": "c"},
+            }
+        },
+        ["gcov", "something", "otherthing", "second", "lalalala"],
+    )
+    assert len(res) == 5
+    assert isinstance(res[0], GcovPlugin)
+    assert isinstance(res[1], NoopPlugin)
+    assert isinstance(res[2], NoopPlugin)
+    assert isinstance(res[3], SecondSamplePlugin)
+    assert isinstance(res[4], NoopPlugin)


### PR DESCRIPTION
The idea here is that customers can set on their YAML their plugins, instead of passing
everything via CLI parameters

This is inspired by https://codecovio.atlassian.net/wiki/spaces/~136505508/pages/2263613441/CLI+Plugin+system+from+the+customer+perspective

The idea is that, if customers want to call a plugin XYZ with parameters alpha beta and gamma set to A, B and C, they go to their YAML:

```
cli:
    plugins:
        myplugin:
            path: XYZ,
            params:
                alpha: A
                beta: B
                gamma: C

```

And then call

```
codecov-cli do-upload --plugin myplugin
```