### PR TITLE
Dana/commit endpoint

### DIFF
--- a/codecov_cli/commands/commit.py
+++ b/codecov_cli/commands/commit.py
@@ -4,6 +4,7 @@ import typing
 import click
 
 from codecov_cli.fallbacks import CodecovOption, FallbackFieldEnum
+from codecov_cli.services.commit import create_commit_logic
 
 logger = logging.getLogger("codecovcli")
 
@@ -14,6 +15,7 @@ logger = logging.getLogger("codecovcli")
     help="Commit SHA (with 40 chars)",
     cls=CodecovOption,
     fallback_field=FallbackFieldEnum.commit_sha,
+    required=True,
 )
 @click.option(
     "--parent-sha",
@@ -21,13 +23,43 @@ logger = logging.getLogger("codecovcli")
 )
 @click.option(
     "--pr",
-    help="Pull Request to associate commit with",
+    help="Pull Request id to associate commit with",
     cls=CodecovOption,
     fallback_field=FallbackFieldEnum.pull_request_number,
 )
+@click.option(
+    "-B",
+    "--branch",
+    help="Branch to which this commit belongs to",
+    cls=CodecovOption,
+    fallback_field=FallbackFieldEnum.branch,
+)
+@click.option(
+    "--slug",
+    cls=CodecovOption,
+    fallback_field=FallbackFieldEnum.slug,
+    help="owner/repo slug used instead of the private repo token in Self-hosted",
+    envvar="CODECOV_SLUG",
+)
 @click.pass_context
 def create_commit(
-    ctx, commit_sha: str, parent_sha: typing.Optional[str], pr: typing.Optional[int]
+    ctx,
+    commit_sha: str,
+    parent_sha: typing.Optional[str],
+    pr: typing.Optional[int],
+    branch: typing.Optional[str],
+    slug: typing.Optional[str],
 ):
-    for x in range(10):
-        logger.info(f"Hello {commit_sha}!")
+    logger.debug(
+        "Starting create commit process",
+        extra=dict(
+            extra_log_attributes=dict(
+                commit_sha=commit_sha,
+                parent_sha=parent_sha,
+                pr=pr,
+                branch=branch,
+                slug=slug,
+            )
+        ),
+    )
+    create_commit_logic(commit_sha, parent_sha, pr)

--- a/codecov_cli/helpers/encoder.py
+++ b/codecov_cli/helpers/encoder.py
@@ -1,0 +1,7 @@
+def encode_slug(slug: str):
+    if "/" not in slug:
+        raise ValueError("The provided slug is invalid")
+    owner, repo = slug.rsplit("/", 1)
+    encoded_owner = ":::".join(owner.split("/"))
+    encoded_slug = "::::".join([encoded_owner, repo])
+    return encoded_slug

--- a/codecov_cli/services/commit/__init__.py
+++ b/codecov_cli/services/commit/__init__.py
@@ -1,0 +1,38 @@
+import logging
+import typing
+
+from codecov_cli.helpers.encoder import encode_slug
+
+from .commit_sender import CommitSender
+
+logger = logging.getLogger("codecovcli")
+
+
+def create_commit_logic(
+    commit_sha: str,
+    parent_sha: typing.Optional[str],
+    pr: typing.Optional[str],
+    branch: typing.Optional[str],
+    slug: typing.Optional[str],
+):
+    encoded_slug = encode_slug(slug)
+    sender = CommitSender()
+    sending_result = sender.send_commit_data(
+        commit_sha=commit_sha,
+        parent_sha=parent_sha,
+        pr=pr,
+        branch=branch,
+        slug=encoded_slug,
+    )
+
+    if sending_result.warnings:
+        number_warnings = len(sending_result.warnings)
+        pluralization = "s" if number_warnings > 1 else ""
+        logger.info(
+            f"Commit creating process had {number_warnings} warning{pluralization}",
+        )
+        for ind, w in enumerate(sending_result.warnings):
+            logger.warning(f"Warning {ind + 1}: {w.message}")
+    if sending_result.error is not None:
+        logger.error(f"Commit creating failed: {sending_result.error.description}")
+    return sending_result

--- a/codecov_cli/services/commit/commit_sender.py
+++ b/codecov_cli/services/commit/commit_sender.py
@@ -1,0 +1,36 @@
+import logging
+
+import requests
+
+from codecov_cli.types import RequestError, RequestResult
+
+logger = logging.getLogger("codecovcli")
+
+
+class CommitSender(object):
+    def send_commit_data(
+        self, commit_sha: str, parent_sha: str, pr: str, branch: str, slug: str
+    ):
+        data = {
+            "commitid": commit_sha,
+            "parent_commit_id": parent_sha,
+            "pullid": pr,
+            "branch": branch,
+        }
+        headers = {}
+
+        resp = requests.post(
+            f"https://codecov.io/upload/{slug}/commits", headers=headers, data=data
+        )
+
+        if resp.status_code >= 400:
+            return RequestResult(
+                error=RequestError(
+                    code=f"HTTP Error {resp.status_code}",
+                    description=resp.text,
+                    params={},
+                ),
+                warnings=[],
+            )
+
+        return RequestResult(error=None, warnings=[])

--- a/codecov_cli/types.py
+++ b/codecov_cli/types.py
@@ -44,3 +44,24 @@ class UploadCollectionResult(object):
 class PreparationPluginInterface(object):
     def run_preparation(self) -> None:
         pass
+
+
+@dataclass
+class RequestResultWarning(object):
+    __slots__ = ("message",)
+    message: str
+
+
+@dataclass
+class RequestError(object):
+    __slots__ = ("code", "params", "description")
+    code: str
+    params: typing.Dict
+    description: str
+
+
+@dataclass
+class RequestResult(object):
+    __slots__ = ("error", "warnings")
+    error: typing.Optional[RequestError]
+    warnings: typing.List[RequestResultWarning]

--- a/tests/helpers/test_encoder.py
+++ b/tests/helpers/test_encoder.py
@@ -1,0 +1,21 @@
+import pytest
+
+from codecov_cli.helpers.encoder import encode_slug
+
+
+def test_invalid_slug():
+    slug = "invalid-slug"
+    with pytest.raises(ValueError) as ex:
+        encode_slug(slug)
+
+
+def test_owner_repo_slug():
+    slug = "owner/repo"
+    encoded_slug = encode_slug(slug)
+    assert encoded_slug == "owner::::repo"
+
+
+def test_owner_with_subgroups_slug():
+    slug = "owner/subgroup/repo"
+    encoded_slug = encode_slug(slug)
+    assert encoded_slug == "owner:::subgroup::::repo"

--- a/tests/test_commit.py
+++ b/tests/test_commit.py
@@ -1,0 +1,100 @@
+from click.testing import CliRunner
+
+from codecov_cli.services.commit import CommitSender, create_commit_logic
+from codecov_cli.types import RequestError, RequestResult, RequestResultWarning
+
+
+def test_commit_command_with_warnings(mocker):
+    mock_send_commit_data = mocker.patch.object(
+        CommitSender,
+        "send_commit_data",
+        return_value=RequestResult(
+            error=None,
+            warnings=[RequestResultWarning(message="somewarningmessage")],
+        ),
+    )
+    runner = CliRunner()
+    with runner.isolation() as outstreams:
+        res = create_commit_logic(
+            commit_sha="commit_sha",
+            parent_sha="parent_sha",
+            pr="pr_num",
+            branch="branch",
+            slug="owner/repo",
+        )
+
+    out_bytes = outstreams[0].getvalue().decode().splitlines()
+    assert out_bytes == [
+        "info: Commit creating process had 1 warning",
+        "warning: Warning 1: somewarningmessage",
+    ]
+    assert res == CommitSender.send_commit_data.return_value
+    mock_send_commit_data.assert_called_with(
+        commit_sha="commit_sha",
+        parent_sha="parent_sha",
+        pr="pr_num",
+        branch="branch",
+        slug="owner::::repo",
+    )
+
+
+def test_commit_command_with_error(mocker):
+    mock_send_commit_data = mocker.patch.object(
+        CommitSender,
+        "send_commit_data",
+        return_value=RequestResult(
+            error=RequestError(
+                code="HTTP Error 403",
+                description="Permission denied",
+                params={},
+            ),
+            warnings=[],
+        ),
+    )
+    runner = CliRunner()
+    with runner.isolation() as outstreams:
+        res = create_commit_logic(
+            commit_sha="commit_sha",
+            parent_sha="parent_sha",
+            pr="pr_num",
+            branch="branch",
+            slug="owner/repo",
+        )
+
+    out_bytes = outstreams[0].getvalue().decode().splitlines()
+    assert out_bytes == ["error: Commit creating failed: Permission denied"]
+    assert res == CommitSender.send_commit_data.return_value
+    mock_send_commit_data.assert_called_with(
+        commit_sha="commit_sha",
+        parent_sha="parent_sha",
+        pr="pr_num",
+        branch="branch",
+        slug="owner::::repo",
+    )
+
+
+def test_commit_sender_200(mocker):
+    mocked_response = mocker.patch(
+        "codecov_cli.services.commit.commit_sender.requests.post",
+        return_value=mocker.MagicMock(status_code=200),
+    )
+    sender = CommitSender()
+    res = sender.send_commit_data("commit_sha", "parent_sha", "pr", "branch", "slug")
+    assert res.error is None
+    assert res.warnings == []
+    mocked_response.assert_called_once()
+
+
+def test_commit_sender_403(mocker):
+    mocked_response = mocker.patch(
+        "codecov_cli.services.commit.commit_sender.requests.post",
+        return_value=mocker.MagicMock(status_code=403, text="Permission denied"),
+    )
+    sender = CommitSender()
+    res = sender.send_commit_data("commit_sha", "parent_sha", "pr", "branch", "slug")
+    assert res.error == RequestError(
+        code="HTTP Error 403",
+        description="Permission denied",
+        params={},
+    )
+    mocked_response.assert_called_once()


### PR DESCRIPTION
This PR: 
- adds logic to create_commit command 
- adds branch and slug as options to the create-commit command 
- creates commitSender which has all logic related to calling the creation commit endpoint 
- encodes owner/repo slug to be owner::::repo, and with subgroups owner/subgroup/repo to be owner:::subgroup::::repo
- creates RequestResult, RequestError and RequestResultWarning which are generic types that can be used with different endpoints. We already have these in the upload sender file which are specified for the upload only, they can be used anywhere so I've moved them to a standalone file with more generic names 

Ticket: [CODE-1921](https://codecovio.atlassian.net/browse/CODE-1921?atlOrigin=eyJpIjoiY2ZlYWI3Yzk4ZjQ2NGM3MWI1NGNjOGM2MDFkZWNmZjgiLCJwIjoiaiJ9)