### PR TITLE
connecting the cli with the report creating endpoint

### DIFF
--- a/codecov_cli/commands/report.py
+++ b/codecov_cli/commands/report.py
@@ -3,6 +3,7 @@ import logging
 import click
 
 from codecov_cli.fallbacks import CodecovOption, FallbackFieldEnum
+from codecov_cli.services.report import create_report_logic
 
 logger = logging.getLogger("codecovcli")
 
@@ -13,11 +14,29 @@ logger = logging.getLogger("codecovcli")
     help="Commit SHA (with 40 chars)",
     cls=CodecovOption,
     fallback_field=FallbackFieldEnum.commit_sha,
+    required=True,
 )
 @click.option(
     "--code", help="The code of the report. If unsure, leave default", default="default"
 )
+@click.option(
+    "--slug",
+    cls=CodecovOption,
+    fallback_field=FallbackFieldEnum.slug,
+    help="owner/repo slug used instead of the private repo token in Self-hosted",
+    envvar="CODECOV_SLUG",
+    required=True,
+)
 @click.pass_context
-def create_report(ctx, commit_sha: str, code: str):
-    for x in range(10):
-        logger.info(f"Hello {commit_sha}!")
+def create_report(ctx, commit_sha: str, code: str, slug: str):
+    logger.debug(
+        "Starting create report process",
+        extra=dict(
+            extra_log_attributes=dict(
+                commit_sha=commit_sha,
+                code=code,
+                slug=slug,
+            )
+        ),
+    )
+    create_report_logic(commit_sha, code, slug)

--- a/codecov_cli/services/report/__init__.py
+++ b/codecov_cli/services/report/__init__.py
@@ -1,0 +1,34 @@
+import logging
+import typing
+
+from codecov_cli.helpers.encoder import encode_slug
+
+from .report_sender import ReportSender
+
+logger = logging.getLogger("codecovcli")
+
+
+def create_report_logic(
+    commit_sha: str,
+    code: str,
+    slug: str,
+):
+    encoded_slug = encode_slug(slug)
+    sender = ReportSender()
+    sending_result = sender.send_report_data(
+        commit_sha=commit_sha,
+        code=code,
+        slug=encoded_slug,
+    )
+
+    if sending_result.warnings:
+        number_warnings = len(sending_result.warnings)
+        pluralization = "s" if number_warnings > 1 else ""
+        logger.info(
+            f"Report creating process had {number_warnings} warning{pluralization}",
+        )
+        for ind, w in enumerate(sending_result.warnings):
+            logger.warning(f"Warning {ind + 1}: {w.message}")
+    if sending_result.error is not None:
+        logger.error(f"Report creating failed: {sending_result.error.description}")
+    return sending_result

--- a/codecov_cli/services/report/report_sender.py
+++ b/codecov_cli/services/report/report_sender.py
@@ -1,0 +1,42 @@
+import logging
+
+import requests
+
+from codecov_cli.types import RequestError, RequestResult
+
+logger = logging.getLogger("codecovcli")
+
+
+class ReportSender(object):
+    def send_report_data(self, commit_sha: str, code: str, slug: str):
+        data = {"code": code}
+        headers = {}
+
+        resp = requests.post(
+            f"https://codecov.io/upload/{slug}/commits/{commit_sha}/reports",
+            headers=headers,
+            data=data,
+        )
+
+        if resp.status_code >= 400:
+            logger.info(f"{resp}")
+            return RequestResult(
+                error=RequestError(
+                    code=f"HTTP Error {resp.status_code}",
+                    description=resp.text,
+                    params={},
+                ),
+                warnings=[],
+            )
+
+        logger.debug(
+            "Finished creating report process successfully",
+            extra=dict(
+                extra_log_attributes=dict(
+                    commit_sha=commit_sha,
+                    code=code,
+                    slug=slug,
+                )
+            ),
+        )
+        return RequestResult(error=None, warnings=[])

--- a/tests/test_report.py
+++ b/tests/test_report.py
@@ -1,0 +1,92 @@
+from click.testing import CliRunner
+
+from codecov_cli.services.report import ReportSender, create_report_logic
+from codecov_cli.types import RequestError, RequestResult, RequestResultWarning
+
+
+def test_report_sender_200(mocker):
+    mocked_response = mocker.patch(
+        "codecov_cli.services.report.report_sender.requests.post",
+        return_value=mocker.MagicMock(status_code=200),
+    )
+    sender = ReportSender()
+    res = sender.send_report_data("commit_sha", "code", "slug")
+    assert res.error is None
+    assert res.warnings == []
+    mocked_response.assert_called_once()
+
+
+def test_report_sender_403(mocker):
+    mocked_response = mocker.patch(
+        "codecov_cli.services.report.report_sender.requests.post",
+        return_value=mocker.MagicMock(status_code=403, text="Permission denied"),
+    )
+    sender = ReportSender()
+    res = sender.send_report_data("commit_sha", "code", "slug")
+    assert res.error == RequestError(
+        code="HTTP Error 403",
+        description="Permission denied",
+        params={},
+    )
+    mocked_response.assert_called_once()
+
+
+def test_report_command_with_warnings(mocker):
+    mock_send_report_data = mocker.patch.object(
+        ReportSender,
+        "send_report_data",
+        return_value=RequestResult(
+            error=None,
+            warnings=[RequestResultWarning(message="somewarningmessage")],
+        ),
+    )
+    runner = CliRunner()
+    with runner.isolation() as outstreams:
+        res = create_report_logic(
+            commit_sha="commit_sha",
+            code="code",
+            slug="owner/repo",
+        )
+
+    out_bytes = outstreams[0].getvalue().decode().splitlines()
+    assert out_bytes == [
+        "info: Report creating process had 1 warning",
+        "warning: Warning 1: somewarningmessage",
+    ]
+    assert res == ReportSender.send_report_data.return_value
+    mock_send_report_data.assert_called_with(
+        commit_sha="commit_sha",
+        code="code",
+        slug="owner::::repo",
+    )
+
+
+def test_report_command_with_error(mocker):
+    mock_send_report_data = mocker.patch.object(
+        ReportSender,
+        "send_report_data",
+        return_value=RequestResult(
+            error=RequestError(
+                code="HTTP Error 403",
+                description="Permission denied",
+                params={},
+            ),
+            warnings=[],
+        ),
+    )
+    runner = CliRunner()
+    with runner.isolation() as outstreams:
+        res = create_report_logic(
+            commit_sha="commit_sha",
+            code="code",
+            slug="owner/repo",
+        )
+
+    out_bytes = outstreams[0].getvalue().decode().splitlines()
+    assert out_bytes == ["error: Report creating failed: Permission denied"]
+    assert res == ReportSender.send_report_data.return_value
+    mock_send_report_data.assert_called_with(
+        commit_sha="commit_sha",
+        code="code",
+        slug="owner::::repo",
+    )


### PR DESCRIPTION
Feature:
We want to connect the cli with the reports endpoint `https://codecov.io/upload/{slug}/commits/{commit_sha}/reports`
This PR provides the structure of the create report command and connects it with the reports endpoint even though the endpoint is still in progress 

Ticket: 
[CODE-1923](https://codecovio.atlassian.net/browse/CODE-1923?atlOrigin=eyJpIjoiYmRjMjY5OGVlMTQxNGQ5NTg3MGNjNmUwYjU4ODMyMWIiLCJwIjoiaiJ9)
