### PR TITLE
add detect ci provider for each provider we have

### DIFF
--- a/codecov_cli/helpers/ci_adapters/appveyor_ci.py
+++ b/codecov_cli/helpers/ci_adapters/appveyor_ci.py
@@ -4,6 +4,11 @@ from codecov_cli.helpers.ci_adapters.base import CIAdapterBase
 
 
 class AppveyorCIAdapter(CIAdapterBase):
+    # https://www.appveyor.com/docs/environment-variables/
+
+    def detect(self) -> bool:
+        return bool(os.getenv("CI")) and bool(os.getenv("APPVEYOR"))
+
     def _get_commit_sha(self):
         return os.getenv("APPVEYOR_PULL_REQUEST_HEAD_COMMIT") or os.getenv(
             "APPVEYOR_REPO_COMMIT"

--- a/codecov_cli/helpers/ci_adapters/azure_pipelines.py
+++ b/codecov_cli/helpers/ci_adapters/azure_pipelines.py
@@ -5,6 +5,10 @@ from codecov_cli.helpers.ci_adapters.base import CIAdapterBase
 
 class AzurePipelinesCIAdapter(CIAdapterBase):
     # https://learn.microsoft.com/en-us/azure/devops/pipelines/build/variables?view=azure-devops&tabs=yaml#build-variables-devops-services
+
+    def detect(self) -> bool:
+        return bool(os.getenv("SYSTEM_TEAMFOUNDATIONCOLLECTIONURI"))
+
     def _get_commit_sha(self):
         return os.getenv("BUILD_SOURCEVERSION")
 

--- a/codecov_cli/helpers/ci_adapters/bitbucket_ci.py
+++ b/codecov_cli/helpers/ci_adapters/bitbucket_ci.py
@@ -4,6 +4,11 @@ from codecov_cli.helpers.ci_adapters.base import CIAdapterBase
 
 
 class BitbucketAdapter(CIAdapterBase):
+    # https://support.atlassian.com/bitbucket-cloud/docs/variables-and-secrets/
+
+    def detect(self) -> bool:
+        return bool(os.getenv("CI")) and bool(os.getenv("BITBUCKET_BUILD_NUMBER"))
+
     def _get_commit_sha(self):
         commit = os.getenv("BITBUCKET_COMMIT")
 

--- a/codecov_cli/helpers/ci_adapters/bitrise_ci.py
+++ b/codecov_cli/helpers/ci_adapters/bitrise_ci.py
@@ -4,6 +4,11 @@ from codecov_cli.helpers.ci_adapters.base import CIAdapterBase
 
 
 class BitriseCIAdapter(CIAdapterBase):
+    # https://devcenter.bitrise.io/en/references/available-environment-variables.html
+
+    def detect(self) -> bool:
+        return bool(os.getenv("CI")) and bool(os.getenv("BITRISE_IO"))
+
     def _get_commit_sha(self):
         return os.getenv("GIT_CLONE_COMMIT_HASH")
 

--- a/codecov_cli/helpers/ci_adapters/buildkite.py
+++ b/codecov_cli/helpers/ci_adapters/buildkite.py
@@ -6,6 +6,9 @@ from codecov_cli.helpers.ci_adapters.base import CIAdapterBase
 class BuildkiteAdapter(CIAdapterBase):
     # https://buildkite.com/docs/pipelines/environment-variables
 
+    def detect(self) -> bool:
+        return bool(os.getenv("BUILDKITE"))
+
     def _get_branch(self):
         return os.getenv("BUILDKITE_BRANCH")
 

--- a/codecov_cli/helpers/ci_adapters/circleci.py
+++ b/codecov_cli/helpers/ci_adapters/circleci.py
@@ -5,6 +5,8 @@ from codecov_cli.helpers.ci_adapters.base import CIAdapterBase
 
 class CircleCICIAdapter(CIAdapterBase):
     # https://circleci.com/docs/2.0/env-vars/#built-in-environment-variables
+    def detect(self) -> bool:
+        return bool(os.getenv("CI")) and bool(os.getenv("CIRCLECI"))
 
     def _get_commit_sha(self):
         return os.getenv("CIRCLE_SHA1")

--- a/codecov_cli/helpers/ci_adapters/cirrus_ci.py
+++ b/codecov_cli/helpers/ci_adapters/cirrus_ci.py
@@ -5,6 +5,8 @@ from codecov_cli.helpers.ci_adapters.base import CIAdapterBase
 
 class CirrusCIAdapter(CIAdapterBase):
     # https://cirrus-ci.org/guide/writing-tasks/#environment-variables
+    def detect(self) -> bool:
+        return bool(os.getenv("CIRRUS_CI"))
 
     def _get_branch(self):
         return os.getenv("CIRRUS_BRANCH")

--- a/codecov_cli/helpers/ci_adapters/droneci.py
+++ b/codecov_cli/helpers/ci_adapters/droneci.py
@@ -5,6 +5,9 @@ from codecov_cli.helpers.ci_adapters.base import CIAdapterBase
 
 class DroneCIAdapter(CIAdapterBase):
     # https://docs.drone.io/pipeline/environment/reference/
+    def detect(self) -> bool:
+        return bool(os.getenv("DRONE"))
+
     def _get_branch(self):
         return os.getenv("DRONE_BRANCH")
 

--- a/codecov_cli/helpers/ci_adapters/github_actions.py
+++ b/codecov_cli/helpers/ci_adapters/github_actions.py
@@ -7,6 +7,8 @@ from codecov_cli.helpers.ci_adapters.base import CIAdapterBase
 
 class GithubActionsCIAdapter(CIAdapterBase):
     # https://docs.github.com/en/actions/learn-github-actions/environment-variables
+    def detect(self) -> bool:
+        return bool(os.getenv("GITHUB_ACTIONS"))
 
     def _get_commit_sha(self):
         pr = self._get_pull_request_number()

--- a/codecov_cli/helpers/ci_adapters/gitlab_ci.py
+++ b/codecov_cli/helpers/ci_adapters/gitlab_ci.py
@@ -6,6 +6,9 @@ from codecov_cli.helpers.git import parse_slug
 
 class GitlabCIAdapter(CIAdapterBase):
     # https://docs.gitlab.com/ee/ci/variables/predefined_variables.html
+    def detect(self) -> bool:
+        return bool(os.getenv("GITLAB_CI"))
+
     def _get_commit_sha(self):
         return (
             os.getenv("CI_MERGE_REQUEST_SOURCE_BRANCH_SHA")

--- a/codecov_cli/helpers/ci_adapters/heroku.py
+++ b/codecov_cli/helpers/ci_adapters/heroku.py
@@ -5,6 +5,8 @@ from codecov_cli.helpers.ci_adapters.base import CIAdapterBase
 
 class HerokuCIAdapter(CIAdapterBase):
     # https://devcenter.heroku.com/articles/heroku-ci#immutable-environment-variables
+    def detect(self) -> bool:
+        return bool(os.getenv("CI")) and bool(os.getenv("HEROKU_TEST_RUN_BRANCH"))
 
     def _get_branch(self):
         return os.getenv("HEROKU_TEST_RUN_BRANCH")

--- a/codecov_cli/helpers/ci_adapters/jenkins.py
+++ b/codecov_cli/helpers/ci_adapters/jenkins.py
@@ -7,6 +7,9 @@ class JenkinsAdapter(CIAdapterBase):
     # https://www.jenkins.io/doc/book/pipeline/jenkinsfile/#using-environment-variables
     # https://www.jenkins.io/doc/book/pipeline/multibranch/
 
+    def detect(self) -> bool:
+        return bool(os.getenv("JENKINS_URL"))
+
     def _get_commit_sha(self):
         return None
 

--- a/codecov_cli/helpers/ci_adapters/local.py
+++ b/codecov_cli/helpers/ci_adapters/local.py
@@ -1,9 +1,16 @@
 import os
+import subprocess
 
 from codecov_cli.helpers.ci_adapters.base import CIAdapterBase
 
+SUCCESS = 0
+
 
 class LocalAdapter(CIAdapterBase):
+    def detect(self) -> bool:
+        s = subprocess.run(["git", "help"], capture_output=True)
+        return s.returncode == SUCCESS
+
     def _get_branch(self):
         return os.getenv("GIT_BRANCH") or os.getenv("BRANCH_NAME")
 

--- a/codecov_cli/helpers/ci_adapters/woodpeckerci.py
+++ b/codecov_cli/helpers/ci_adapters/woodpeckerci.py
@@ -5,6 +5,8 @@ from codecov_cli.helpers.ci_adapters.base import CIAdapterBase
 
 class WoodpeckerCIAdapter(CIAdapterBase):
     # https://woodpecker-ci.org/docs/usage/environment
+    def detect(self) -> bool:
+        return os.getenv("CI") == "woodpecker"
 
     def _get_branch(self):
         return os.getenv("CI_COMMIT_SOURCE_BRANCH") or os.getenv("CI_COMMIT_BRANCH")

--- a/tests/ci_adapters/test_appveyor.py
+++ b/tests/ci_adapters/test_appveyor.py
@@ -19,9 +19,26 @@ class AppveyorCIEnvEnum(str, Enum):
     APPVEYOR_REPO_COMMIT = "APPVEYOR_REPO_COMMIT"
     APPVEYOR_REPO_NAME = "APPVEYOR_REPO_NAME"
     APPVEYOR_URL = "APPVEYOR_URL"
+    CI = "CI"
+    APPVEYOR = "APPVEYOR"
 
 
 class TestAppveyorCI(object):
+    @pytest.mark.parametrize(
+        "env_dict,expected",
+        [
+            ({}, False),
+            (
+                {AppveyorCIEnvEnum.CI: "True", AppveyorCIEnvEnum.APPVEYOR: "True"},
+                True,
+            ),
+        ],
+    )
+    def test_detect(self, env_dict, expected, mocker):
+        mocker.patch.dict(os.environ, env_dict)
+        actual = AppveyorCIAdapter().detect()
+        assert actual == expected
+
     @pytest.mark.parametrize(
         "env_dict,expected",
         [

--- a/tests/ci_adapters/test_azure_pipelines.py
+++ b/tests/ci_adapters/test_azure_pipelines.py
@@ -23,6 +23,21 @@ class TestAzurePipelines(object):
     @pytest.mark.parametrize(
         "env_dict,expected",
         [
+            ({}, False),
+            (
+                {AzurePipelinesEnvEnum.SYSTEM_TEAMFOUNDATIONCOLLECTIONURI: "1234"},
+                True,
+            ),
+        ],
+    )
+    def test_detect(self, env_dict, expected, mocker):
+        mocker.patch.dict(os.environ, env_dict)
+        actual = AzurePipelinesCIAdapter().detect()
+        assert actual == expected
+
+    @pytest.mark.parametrize(
+        "env_dict,expected",
+        [
             ({}, None),
             (
                 {AzurePipelinesEnvEnum.BUILD_SOURCEVERSION: "123456789000111"},

--- a/tests/ci_adapters/test_bitbucket_ci.py
+++ b/tests/ci_adapters/test_bitbucket_ci.py
@@ -13,9 +13,29 @@ class BitbucketEnvEnum(str, Enum):
     BITBUCKET_PR_ID = "BITBUCKET_PR_ID"
     BITBUCKET_COMMIT = "BITBUCKET_COMMIT"
     BITBUCKET_REPO_FULL_NAME = "BITBUCKET_REPO_FULL_NAME"
+    CI = "CI"
 
 
 class TestBitbucket(object):
+    @pytest.mark.parametrize(
+        "env_dict,expected",
+        [
+            ({}, False),
+            (
+                {
+                    BitbucketEnvEnum.CI: "true",
+                    BitbucketEnvEnum.BITBUCKET_BUILD_NUMBER: "123",
+                },
+                True,
+            ),
+        ],
+    )
+    def test_detect(self, env_dict, expected, mocker):
+        mocker.patch.dict(os.environ, env_dict)
+        actual = BitbucketAdapter().detect()
+
+        assert actual == expected
+
     @pytest.mark.parametrize(
         "env_dict,expected",
         [

--- a/tests/ci_adapters/test_bitrise.py
+++ b/tests/ci_adapters/test_bitrise.py
@@ -13,9 +13,26 @@ class BitriseEnvEnum(str, Enum):
     BITRISE_BUILD_NUMBER = "BITRISE_BUILD_NUMBER"
     BITRISE_BUILD_URL = "BITRISE_BUILD_URL"
     GIT_CLONE_COMMIT_HASH = "GIT_CLONE_COMMIT_HASH"
+    CI = "CI"
+    BITRISE_IO = "BITRISE_IO"
 
 
 class TestBitrise(object):
+    @pytest.mark.parametrize(
+        "env_dict,expected",
+        [
+            ({}, False),
+            (
+                {BitriseEnvEnum.CI: "true", BitriseEnvEnum.BITRISE_IO: "true"},
+                True,
+            ),
+        ],
+    )
+    def test_detect(self, env_dict, expected, mocker):
+        mocker.patch.dict(os.environ, env_dict)
+        actual = BitriseCIAdapter().detect()
+        assert actual == expected
+
     @pytest.mark.parametrize(
         "env_dict,expected",
         [

--- a/tests/ci_adapters/test_buildkite.py
+++ b/tests/ci_adapters/test_buildkite.py
@@ -16,9 +16,25 @@ class BuildkiteEnvEnum(str, Enum):
     BUILDKITE_PIPELINE_SLUG = "BUILDKITE_PIPELINE_SLUG"
     BUILDKITE_PULL_REQUEST = "BUILDKITE_PULL_REQUEST"
     BUILDKITE_JOB_ID = "BUILDKITE_JOB_ID"
+    BUILDKITE = "BUILDKITE"
 
 
 class TestBuildkite(object):
+    @pytest.mark.parametrize(
+        "env_dict,expected",
+        [
+            ({}, False),
+            (
+                {BuildkiteEnvEnum.BUILDKITE: "true"},
+                True,
+            ),
+        ],
+    )
+    def test_detect(self, env_dict, expected, mocker):
+        mocker.patch.dict(os.environ, env_dict)
+        actual = BuildkiteAdapter().detect()
+        assert actual == expected
+
     @pytest.mark.parametrize(
         "env_dict,expected",
         [

--- a/tests/ci_adapters/test_circleci.py
+++ b/tests/ci_adapters/test_circleci.py
@@ -17,9 +17,23 @@ class CircleCIEnvEnum(str, Enum):
     CIRCLE_PROJECT_REPONAME = "CIRCLE_PROJECT_REPONAME"
     CIRCLE_REPOSITORY_URL = "CIRCLE_REPOSITORY_URL"
     CIRCLE_BRANCH = "CIRCLE_BRANCH"
+    CI = "CI"
+    CIRCLECI = "CIRCLECI"
 
 
 class TestCircleCI(object):
+    @pytest.mark.parametrize(
+        "env_dict,expected",
+        [
+            ({}, False),
+            ({CircleCIEnvEnum.CI: "true", CircleCIEnvEnum.CIRCLECI: "true"}, True),
+        ],
+    )
+    def test_detect(self, env_dict, expected, mocker):
+        mocker.patch.dict(os.environ, env_dict)
+        actual = CircleCICIAdapter().detect()
+        assert actual == expected
+
     @pytest.mark.parametrize(
         "env_dict,expected",
         [

--- a/tests/ci_adapters/test_cirrusci.py
+++ b/tests/ci_adapters/test_cirrusci.py
@@ -14,9 +14,25 @@ class CirrusEnvEnum(str, Enum):
     CIRRUS_REPO_FULL_NAME = "CIRRUS_REPO_FULL_NAME"
     CIRRUS_PR = "CIRRUS_PR"
     CIRRUS_TASK_ID = "CIRRUS_TASK_ID"
+    CIRRUS_CI = "CIRRUS_CI"
 
 
 class TestCirrus(object):
+    @pytest.mark.parametrize(
+        "env_dict,expected",
+        [
+            ({}, False),
+            (
+                {CirrusEnvEnum.CIRRUS_CI: "true"},
+                True,
+            ),
+        ],
+    )
+    def test_detect(self, env_dict, expected, mocker):
+        mocker.patch.dict(os.environ, env_dict)
+        actual = CirrusCIAdapter().detect()
+        assert actual == expected
+
     @pytest.mark.parametrize(
         "env_dict,expected",
         [

--- a/tests/ci_adapters/test_droneci.py
+++ b/tests/ci_adapters/test_droneci.py
@@ -14,9 +14,22 @@ class DroneCIEnvEnum(str, Enum):
     DRONE_COMMIT_SHA = "DRONE_COMMIT_SHA"
     DRONE_REPO = "DRONE_REPO"
     DRONE_PULL_REQUEST = "DRONE_PULL_REQUEST"
+    DRONE = "DRONE"
 
 
 class TestDroneCI(object):
+    @pytest.mark.parametrize(
+        "env_dict,expected",
+        [
+            ({}, False),
+            ({DroneCIEnvEnum.DRONE: "true"}, True),
+        ],
+    )
+    def test_detect(self, env_dict, expected, mocker):
+        mocker.patch.dict(os.environ, env_dict)
+        actual = DroneCIAdapter().detect()
+        assert actual == expected
+
     @pytest.mark.parametrize(
         "env_dict,expected",
         [

--- a/tests/ci_adapters/test_ghactions.py
+++ b/tests/ci_adapters/test_ghactions.py
@@ -15,9 +15,24 @@ class GithubActionsEnvEnum(str, Enum):
     GITHUB_HEAD_REF = "GITHUB_HEAD_REF"
     GITHUB_REF = "GITHUB_REF"
     GITHUB_REPOSITORY = "GITHUB_REPOSITORY"
+    GITHUB_ACTIONS = "GITHUB_ACTIONS"
 
 
 class TestGithubActions(object):
+    @pytest.mark.parametrize(
+        "env_dict,expected",
+        [
+            (
+                {GithubActionsEnvEnum.GITHUB_ACTIONS: "true"},
+                True,
+            ),
+        ],
+    )
+    def test_detect(self, env_dict, expected, mocker):
+        mocker.patch.dict(os.environ, env_dict)
+        actual = GithubActionsCIAdapter().detect()
+        assert actual == expected
+
     def test_commit_sha_if_not_in_merge_commit(self, mocker):
         mocker.patch.dict(
             os.environ, {GithubActionsEnvEnum.GITHUB_SHA: "1234"}, clear=True

--- a/tests/ci_adapters/test_gitlabci.py
+++ b/tests/ci_adapters/test_gitlabci.py
@@ -22,9 +22,21 @@ class GitlabCIEnvEnum(str, Enum):
     CI_MERGE_REQUEST_IID = "CI_MERGE_REQUEST_IID"
     CI_PROJECT_NAMESPACE = "CI_PROJECT_NAMESPACE"
     CI_PROJECT_NAME = "CI_PROJECT_NAME"
+    GITLAB_CI = "GITLAB_CI"
 
 
 class TestGitlabCI(object):
+    @pytest.mark.parametrize(
+        "env_dict,expected",
+        [
+            ({}, False),
+            ({GitlabCIEnvEnum.GITLAB_CI: "true"}, True),
+        ],
+    )
+    def test_detect(self, env_dict, expected, mocker):
+        mocker.patch.dict(os.environ, env_dict, expected)
+        assert GitlabCIAdapter().detect() == expected
+
     @pytest.mark.parametrize(
         "env_dict,expected",
         [

--- a/tests/ci_adapters/test_herokuci.py
+++ b/tests/ci_adapters/test_herokuci.py
@@ -11,9 +11,28 @@ class HerokuCIEnvEnum(str, Enum):
     HEROKU_TEST_RUN_BRANCH = "HEROKU_TEST_RUN_BRANCH"
     HEROKU_TEST_RUN_COMMIT_VERSION = "HEROKU_TEST_RUN_COMMIT_VERSION"
     HEROKU_TEST_RUN_ID = "HEROKU_TEST_RUN_ID"
+    CI = "CI"
 
 
 class TestHerokuCI(object):
+    @pytest.mark.parametrize(
+        "env_dict,expected",
+        [
+            ({}, False),
+            (
+                {
+                    HerokuCIEnvEnum.CI: "true",
+                    HerokuCIEnvEnum.HEROKU_TEST_RUN_BRANCH: "123",
+                },
+                True,
+            ),
+        ],
+    )
+    def test_detect(self, env_dict, expected, mocker):
+        mocker.patch.dict(os.environ, env_dict)
+        actual = HerokuCIAdapter().detect()
+        assert actual == expected
+
     @pytest.mark.parametrize(
         "env_dict,expected",
         [

--- a/tests/ci_adapters/test_jenkins.py
+++ b/tests/ci_adapters/test_jenkins.py
@@ -12,9 +12,34 @@ class JenkinsCIEnvEnum(str, Enum):
     BUILD_NUMBER = "BUILD_NUMBER"
     CHANGE_ID = "CHANGE_ID"
     BRANCH_NAME = "BRANCH_NAME"
+    JENKINS_URL = "JENKINS_URL"
 
 
 class TestJenkins(object):
+    @pytest.mark.parametrize(
+        "env_dict,expected",
+        [
+            ({}, False),
+            ({JenkinsCIEnvEnum.JENKINS_URL: "url"}, True),
+        ],
+    )
+    def test_detect(self, env_dict, expected, mocker):
+        mocker.patch.dict(os.environ, env_dict)
+        actual = JenkinsAdapter().detect()
+        assert actual == expected
+
+    @pytest.mark.parametrize(
+        "env_dict,expected",
+        [
+            ({}, None),
+            ({JenkinsCIEnvEnum.BUILD_URL: "url"}, "url"),
+        ],
+    )
+    def test_build_url(self, env_dict, expected, mocker):
+        mocker.patch.dict(os.environ, env_dict)
+        actual = JenkinsAdapter().get_fallback_value(FallbackFieldEnum.build_url)
+        assert actual == expected
+
     @pytest.mark.parametrize(
         "env_dict,expected",
         [

--- a/tests/ci_adapters/test_local.py
+++ b/tests/ci_adapters/test_local.py
@@ -14,6 +14,22 @@ class LocalEnvEnum(str, Enum):
 
 
 class TestLocalAdapter(object):
+    def test_detect(self, mocker):
+        mocked_subprocess = mocker.patch(
+            "codecov_cli.helpers.ci_adapters.local.subprocess.run",
+            return_value=mocker.MagicMock(returncode=0),
+        )
+        assert LocalAdapter().detect()
+        mocked_subprocess.assert_called_once()
+
+    def test_detect_git_not_installed(self, mocker):
+        mocked_subprocess = mocker.patch(
+            "codecov_cli.helpers.ci_adapters.local.subprocess.run",
+            return_value=mocker.MagicMock(returncode=1),
+        )
+        assert LocalAdapter().detect() == False
+        mocked_subprocess.assert_called_once()
+
     @pytest.mark.parametrize(
         "env_dict,expected",
         [

--- a/tests/ci_adapters/test_woodpeckerci.py
+++ b/tests/ci_adapters/test_woodpeckerci.py
@@ -16,9 +16,22 @@ class WoodpeckerEnvEnum(str, Enum):
     CI_REPO = "CI_REPO"
     CI_COMMIT_PULL_REQUEST = "CI_COMMIT_PULL_REQUEST"
     CI_JOB_NUMBER = "CI_JOB_NUMBER"
+    CI = "CI"
 
 
 class TestWoodpecker(object):
+    @pytest.mark.parametrize(
+        "env_dict,expected",
+        [
+            ({}, False),
+            ({WoodpeckerEnvEnum.CI: "woodpecker"}, True),
+            ({WoodpeckerEnvEnum.CI: "true"}, False),
+        ],
+    )
+    def test_detect(self, env_dict, expected, mocker):
+        mocker.patch.dict(os.environ, env_dict, expected)
+        assert WoodpeckerCIAdapter().detect() == expected
+
     @pytest.mark.parametrize(
         "env_dict,expected",
         [


### PR DESCRIPTION
In order to automatically detect the ci provider without any user interference, we'll have to loop through all providers we have and detect if it exists through some environment variables 
Notice that many providers have the same env variable which is "CI", so we use another one such as build id for that specific provider 
This is being copied from the node uploader