### PR TITLE
Add --fail-on-error option to do-upload command

### DIFF
--- a/codecov_cli/commands/upload.py
+++ b/codecov_cli/commands/upload.py
@@ -146,6 +146,13 @@ def _turn_env_vars_into_dict(ctx, params, value):
 @click.option(
     "--plugin", "plugin_names", multiple=True, default=["xcode", "gcov", "pycoverage"]
 )
+@click.option(
+    "-Z",
+    "--fail-on-error",
+    "fail_on_error",
+    is_flag=True,
+    help="Exit with non-zero code in case of error uploading.",
+)
 @click.option("--use-new-uploader", "is_using_new_uploader", default=False)
 @click.pass_context
 def do_upload(
@@ -168,6 +175,7 @@ def do_upload(
     slug: typing.Optional[str],
     pull_request_number: typing.Optional[str],
     is_using_new_uploader: bool,
+    fail_on_error: bool,
 ):
     versioning_system = ctx.obj["versioning_system"]
     codecov_yaml = ctx.obj["codecov_yaml"] or {}
@@ -219,4 +227,5 @@ def do_upload(
         slug=slug,
         pull_request_number=pull_request_number,
         is_using_new_uploader=is_using_new_uploader,
+        fail_on_error=fail_on_error,
     )

--- a/codecov_cli/helpers/request.py
+++ b/codecov_cli/helpers/request.py
@@ -47,7 +47,9 @@ def request_result(resp):
     )
 
 
-def log_warnings_and_errors_if_any(sending_result: RequestResult, process_desc):
+def log_warnings_and_errors_if_any(
+    sending_result: RequestResult, process_desc: str, fail_on_error: bool = False
+):
     if sending_result.warnings:
         number_warnings = len(sending_result.warnings)
         pluralization = "s" if number_warnings > 1 else ""
@@ -58,3 +60,5 @@ def log_warnings_and_errors_if_any(sending_result: RequestResult, process_desc):
             logger.warning(f"Warning {ind + 1}: {w.message}")
     if sending_result.error is not None:
         logger.error(f"{process_desc} failed: {sending_result.error.description}")
+        if fail_on_error:
+            exit(1)

--- a/codecov_cli/services/legacy_upload/__init__.py
+++ b/codecov_cli/services/legacy_upload/__init__.py
@@ -44,6 +44,7 @@ def do_upload_logic(
     slug: typing.Optional[str],
     pull_request_number: typing.Optional[str],
     is_using_new_uploader: bool = False,
+    fail_on_error: bool = False
 ):
     preparation_plugins = select_preparation_plugins(cli_config, plugin_names)
     coverage_file_selector = select_coverage_file_finder(
@@ -81,5 +82,5 @@ def do_upload_logic(
         flags,
         service,
     )
-    log_warnings_and_errors_if_any(sending_result, "Upload")
+    log_warnings_and_errors_if_any(sending_result, "Upload", fail_on_error)
     return sending_result

--- a/tests/helpers/test_request.py
+++ b/tests/helpers/test_request.py
@@ -1,0 +1,30 @@
+import pytest
+
+from codecov_cli.helpers.request import log_warnings_and_errors_if_any
+from codecov_cli.helpers.request import logger as req_log
+from codecov_cli.types import RequestError, RequestResult
+
+
+def test_log_error_no_raise(mocker):
+    mock_log_error = mocker.patch.object(req_log, "error")
+    error = RequestError(
+        code=401, params={"some": "params"}, description="Unauthorized"
+    )
+    result = RequestResult(
+        error=error, warnings=[], status_code=401, text="Unauthorized"
+    )
+    log_warnings_and_errors_if_any(result, "Process", fail_on_error=False)
+    mock_log_error.assert_called_with(f"Process failed: Unauthorized")
+
+
+def test_log_error_raise(mocker):
+    mock_log_error = mocker.patch.object(req_log, "error")
+    error = RequestError(
+        code=401, params={"some": "params"}, description="Unauthorized"
+    )
+    result = RequestResult(
+        error=error, warnings=[], status_code=401, text="Unauthorized"
+    )
+    with pytest.raises(SystemExit):
+        log_warnings_and_errors_if_any(result, "Process", fail_on_error=True)
+    mock_log_error.assert_called_with(f"Process failed: Unauthorized")

--- a/tests/test_upload.py
+++ b/tests/test_upload.py
@@ -1,6 +1,8 @@
 from click.testing import CliRunner
 
 from codecov_cli.main import cli
+from codecov_cli.services.legacy_upload import UploadSender
+from codecov_cli.types import RequestError, RequestResult
 
 
 def test_upload_missing_commit_sha(mocker):
@@ -13,3 +15,21 @@ def test_upload_missing_commit_sha(mocker):
     result = runner.invoke(cli, ["do-upload"], obj={})
     assert result.exit_code != 0
     assert "Missing option '-C' / '--sha' / '--commit-sha'" in result.output
+
+
+def test_upload_raise_Z_option(mocker):
+    error = RequestError(
+        code=401, params={"some": "params"}, description="Unauthorized"
+    )
+    result = RequestResult(
+        error=error, warnings=[], status_code=401, text="Unauthorized"
+    )
+    upload_sender = mocker.patch.object(
+        UploadSender, "send_upload_data", return_value=result
+    )
+    runner = CliRunner()
+    result = runner.invoke(
+        cli, ["do-upload", "--fail-on-error", "--use-new-uploader=True"], obj={}
+    )
+    upload_sender.assert_called
+    assert str(result) == "<Result SystemExit(1)>"


### PR DESCRIPTION
`--fail-on-error` forces a `SystemExit(1)` in case of errors when uploading. This was the `--nonZero` option in the legacy uploader.