### PR TITLE
Small fixed to make developping smoother

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,6 @@
+name ?= codecovcli
+
+lint:
+	pip install black==22.3.0 isort==5.10.1
+	black .
+	isort --profile black .

--- a/tests/plugins/test_xcode.py
+++ b/tests/plugins/test_xcode.py
@@ -114,3 +114,4 @@ class TestXcode(object):
         mocked_subprocess.assert_called_once()
         file_path = pathlib.Path("llvm-output-test")
         assert file_path.is_file()
+        file_path.unlink()


### PR DESCRIPTION
- Create a Makefile with the `make lint` command so we don't have to do it manually
- Clean the `llvm-output-test` file generated by tests so we don't have it dangling around