### PR TITLE
Change default plugin list to empty.

### DIFF
--- a/codecov_cli/commands/upload.py
+++ b/codecov_cli/commands/upload.py
@@ -143,9 +143,7 @@ def _turn_env_vars_into_dict(ctx, params, value):
     default=[],
     help="Flag the upload to group coverage metrics. Multiple flags allowed.",
 )
-@click.option(
-    "--plugin", "plugin_names", multiple=True, default=["xcode", "gcov", "pycoverage"]
-)
+@click.option("--plugin", "plugin_names", multiple=True, default=[])
 @click.option(
     "-Z",
     "--fail-on-error",

--- a/tests/plugins/test_instantiation.py
+++ b/tests/plugins/test_instantiation.py
@@ -1,3 +1,6 @@
+from codecov_cli.plugins.pycoverage import Pycoverage
+import pytest
+
 from codecov_cli.plugins import (
     GcovPlugin,
     NoopPlugin,
@@ -42,14 +45,18 @@ def test_load_plugin_from_yaml_bad_parameters(mocker):
     assert isinstance(res, NoopPlugin)
 
 
-def test_get_plugin_gcov():
-    res = _get_plugin({}, "gcov")
-    assert isinstance(res, GcovPlugin)
-
-
-def test_get_plugin_xcode():
-    res = _get_plugin({}, "xcode")
-    assert isinstance(res, XcodePlugin)
+@pytest.mark.parametrize(
+    "plugin_name,expected_class",
+    [
+        ("gcov", GcovPlugin),
+        ("xcode", XcodePlugin),
+        ("pycoverage", Pycoverage),
+        (None, NoopPlugin),
+    ],
+)
+def test_get_plugin_by_name(plugin_name, expected_class):
+    plugin = _get_plugin({}, plugin_name)
+    assert isinstance(plugin, expected_class)
 
 
 def test_select_preparation_plugins(mocker):


### PR DESCRIPTION
While it's possible to override the default, it's not possible to run the `do-upload` command without calling any plugins. So we are changing the default to be the empty list and users can call the plugins they need normally.