### PR TITLE
Fix lint command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,5 +2,7 @@ name ?= codecovcli
 
 lint:
 	pip install black==22.3.0 isort==5.10.1
-	black .
-	isort --profile black .
+	black codecov_cli/**
+	isort --profile black codecov_cli/**
+	black tests/**
+	isort --profile black tests/**


### PR DESCRIPTION
Because there are git submodules now doing `black .` will change files inside those submodules, which is not what we want. Breaking up the commands to only affect the code we want to lint.