### PR TITLE
Make ci.yml more similar to python-package.yml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+        with:
+          submodules: true
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
@@ -21,7 +23,7 @@ jobs:
           black --check codecov_cli
       - name: Check imports order with isort
         run: |
-          isort --check --profile=black codecov_cli
+          isort --check --profile=black codecov_cli -p staticcodecov_languages
 
 
   build:
@@ -33,14 +35,12 @@ jobs:
     steps:
     - uses: actions/checkout@v3
       with:
+        submodules: true
         fetch-depth: 2
     - name: Set up Python 3.10
       uses: actions/setup-python@v3
       with:
         python-version: "3.10"
-    - name: Git Sumbodule Update
-      run: |
-        git pull --recurse-submodules
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
@@ -60,6 +60,8 @@ jobs:
     needs: build
     steps:
     - uses: actions/checkout@v3
+      with:
+        submodules: true
     - name: Build executable with pyinstaller 
       run: |
         pip install pyinstaller


### PR DESCRIPTION
Recently we had some builds failing on the CI file but not on the python-package one. Probably a result of changes that happened only in python-package. They might have diverged, bringing them together again.