### PR TITLE
add detect function to CodeBuild ci provider

### DIFF
--- a/codecov_cli/helpers/ci_adapters/codebuild.py
+++ b/codecov_cli/helpers/ci_adapters/codebuild.py
@@ -6,6 +6,8 @@ from codecov_cli.helpers.ci_adapters.base import CIAdapterBase
 
 class AWSCodeBuildCIAdapter(CIAdapterBase):
     # https://docs.aws.amazon.com/codebuild/latest/userguide/build-env-ref-env-vars.html
+    def detect(self) -> bool:
+        return bool(os.getenv("CODEBUILD_CI"))
 
     def _get_branch(self):
         branch = os.getenv("CODEBUILD_WEBHOOK_HEAD_REF")

--- a/tests/ci_adapters/test_codebuild.py
+++ b/tests/ci_adapters/test_codebuild.py
@@ -13,9 +13,22 @@ class CodeBuildEnvEnum(str, Enum):
     CODEBUILD_RESOLVED_SOURCE_VERSION = "CODEBUILD_RESOLVED_SOURCE_VERSION"
     CODEBUILD_SOURCE_REPO_URL = "CODEBUILD_SOURCE_REPO_URL"
     CODEBUILD_SOURCE_VERSION = "CODEBUILD_SOURCE_VERSION"
+    CODEBUILD_CI = "CODEBUILD_CI"
 
 
 class TestCodeBuild(object):
+    @pytest.mark.parametrize(
+        "env_dict,expected",
+        [
+            ({}, False),
+            ({CodeBuildEnvEnum.CODEBUILD_CI: "true"}, True),
+        ],
+    )
+    def test_detect(self, env_dict, expected, mocker):
+        mocker.patch.dict(os.environ, env_dict)
+        actual = AWSCodeBuildCIAdapter().detect()
+        assert actual == expected
+
     @pytest.mark.parametrize(
         "env_dict,expected",
         [


### PR DESCRIPTION
We're missing the detect method which returns NotImplementedError 