### PR TITLE
Fix path_fixes in upload payload

### DIFF
--- a/codecov_cli/services/upload/upload_sender.py
+++ b/codecov_cli/services/upload/upload_sender.py
@@ -68,6 +68,7 @@ class UploadSender(object):
             "coverage_files": self._get_coverage_files(upload_data),
             "metadata": {},
         }
+
         json_data = json.dumps(payload)
         return json_data.encode()
 
@@ -92,7 +93,7 @@ class UploadSender(object):
             total_fixed_lines = list(
                 file_fixer.fixed_lines_without_reason.union(fixed_lines_with_reason)
             )
-            file_fixers[file_fixer.path] = {
+            file_fixers[str(file_fixer.path)] = {
                 "eof": file_fixer.eof,
                 "lines": total_fixed_lines,
             }

--- a/tests/helpers/test_upload_sender.py
+++ b/tests/helpers/test_upload_sender.py
@@ -1,5 +1,6 @@
 import json
 import uuid
+from pathlib import Path
 
 import pytest
 import responses
@@ -87,7 +88,7 @@ def get_fake_upload_collection_result(mocked_coverage_file):
     coverage_files = [mocked_coverage_file, mocked_coverage_file]
     path_fixers = [
         UploadCollectionResultFileFixer(
-            path="SwiftExample/AppDelegate.swift",
+            path=Path("SwiftExample/AppDelegate.swift"),
             fixed_lines_without_reason=set([1, 2, 3, 4, 9, 10, 11]),
             fixed_lines_with_reason=set(
                 [
@@ -100,7 +101,7 @@ def get_fake_upload_collection_result(mocked_coverage_file):
             eof=15,
         ),
         UploadCollectionResultFileFixer(
-            path="SwiftExample/Hello.swift",
+            path=Path("SwiftExample/Hello.swift"),
             fixed_lines_without_reason=set([1, 3, 7, 9, 12, 14]),
             fixed_lines_with_reason=set(
                 [
@@ -111,7 +112,7 @@ def get_fake_upload_collection_result(mocked_coverage_file):
             eof=30,
         ),
         UploadCollectionResultFileFixer(
-            path="SwiftExample/ViewController.swift",
+            path=Path("SwiftExample/ViewController.swift"),
             fixed_lines_without_reason=set(
                 [1, 4, 5, 6, 7, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 22, 26]
             ),


### PR DESCRIPTION
Recently testing the CLI with the new upload endpoint I had the following error (when trying to upload the CLI itself)
```
TypeError: keys must be str, int, float, bool or None, not PosixPath
Error: Process completed with exit code 1.
```

After some digging I found the keys in question
```
Finding the PosixPath
Key languages/languages.c is PosixPath. Origin: .path_fixes.value[languages/languages.c]
Key tests/data/files_to_fix_examples/sample.cpp is PosixPath. Origin: .path_fixes.value[tests/data/files_to_fix_examples/sample.cpp]
Key tests/data/files_to_fix_examples/sample.go is PosixPath. Origin: .path_fixes.value[tests/data/files_to_fix_examples/sample.go]
Key tests/data/files_to_fix_examples/sample.kt is PosixPath. Origin: .path_fixes.value[tests/data/files_to_fix_examples/sample.kt]
Key tests/data/files_to_fix_examples/sample.php is PosixPath. Origin: .path_fixes.value[tests/data/files_to_fix_examples/sample.php]
Finding the PosixPath ================ END
```

They come from the path_fixes, which are of class Path, but need to be strings. To solve this we simply cast them to string while building the payload.

The reason this was not picked up in the unit tests before is that we were already passing strings, not Path as it should be.