### PR TITLE
Cast multiple=True args in upload to list

### DIFF
--- a/codecov_cli/commands/upload.py
+++ b/codecov_cli/commands/upload.py
@@ -57,7 +57,7 @@ def _turn_env_vars_into_dict(ctx, params, value):
     help="Folders where to search for coverage files",
     type=click.Path(path_type=pathlib.Path),
     multiple=True,
-    default=None,
+    default=[],
 )
 @click.option(
     "-f",
@@ -67,7 +67,7 @@ def _turn_env_vars_into_dict(ctx, params, value):
     help="Explicit files to upload",
     type=click.Path(path_type=pathlib.Path),
     multiple=True,
-    default=None,
+    default=[],
 )
 @click.option(
     "-b",
@@ -242,8 +242,12 @@ def do_upload(
         name=name,
         network_root_folder=network_root_folder,
         coverage_files_search_root_folder=coverage_files_search_root_folder,
-        coverage_files_search_exclude_folders=coverage_files_search_exclude_folders,
-        coverage_files_search_explicitly_listed_files=coverage_files_search_explicitly_listed_files,
+        coverage_files_search_exclude_folders=list(
+            coverage_files_search_exclude_folders
+        ),
+        coverage_files_search_explicitly_listed_files=list(
+            coverage_files_search_explicitly_listed_files
+        ),
         plugin_names=plugin_names,
         token=token,
         branch=branch,


### PR DESCRIPTION
Recently when trying out the CLI with the new upload endpoint I tried to use the `--exclude` option but got the following error:
```
File "/Users/giovannimguidini/Projects/GitHub/codecov-cli/codecov_cli/services/upload/coverage_file_finder.py", line 179, in find_coverage_files
    default_folders_to_ignore + self.folders_to_ignore,
TypeError: can only concatenate list (not "tuple") to list
```

Investigating it deeper we try to merge 2 lists, with one of them being actually a tuple indeed:
```
default_folders_to_ignore has type <class 'list'>
self.folders_to_ignore has type <class 'tuple'>
```

Click documentation doesn't specify if the default cliss for options with `multiple=True` is `tuple` or `list`, nor did I find a click type for it. So instead I'm just casting the argument passed by click to be sure. I changed the default so it would still work if we don't use those options.