### PR TITLE
send a pub/sub message with the release tag to publish the release

### DIFF
--- a/.github/workflows/release_flow.yml
+++ b/.github/workflows/release_flow.yml
@@ -112,14 +112,20 @@ jobs:
   publish_release:
     name: Publish release
     needs: buildassets
-      # Authenticate with gcloud using OIDC
-    - name: Authenticate with GCP using OIDC
-      run: |
-        echo "${{ secrets.GCP_SERVICE_ACCOUNT_KEY }}" > gcp-service-account.json
-        gcloud auth activate-service-account --key-file=gcp-service-account.json
-        gcloud auth login --update-adc
+    runs-on: ubuntu-latest
+    permissions:
+      contents: 'read'
+      id-token: 'write'
+    steps:
+      - id: 'auth'
+        name: 'Authenticate to Google Cloud'
+        uses: 'google-github-actions/auth@v1.0.0'
+        with:
+          create_credentials_file: 'true'
+          workload_identity_provider: ${{ secrets.CODECOV_GCP_WIDP }}
+          service_account: ${{ secrets.CODECOV_GCP_WIDSA }}
 
-    # Publish the release tag to a Pub/Sub topic
-    - name: Publish a message to a Pub/Sub topic
-      run: |
-        gcloud pubsub topics publish ${{ secrets.GCLOUD_UPLOADER_PUBSUB_TOPIC }} --message '{"release":"'"${{ github.ref_name }}"'", "latest":true}'
+      # Publish the release tag to a Pub/Sub topic
+      - name: Publish a message to a Pub/Sub topic
+        run: |
+          gcloud pubsub topics publish ${{ secrets.GCLOUD_UPLOADER_PUBSUB_TOPIC }} --message '{"release":"'"${{ github.ref_name }}"'", "latest":true}'


### PR DESCRIPTION
This PR sends a pub/sub message with the release tag to GCP after it authenticates with GCP using OIDC
We need to set the values for GCP_SERVICE_ACCOUNT_KEY and GCLOUD_UPLOADER_PUBSUB_TOPIC in the env secrets 