### PR TITLE
Scaffold runner system for label analysis

### DIFF
--- a/codecov_cli/runners/__init__.py
+++ b/codecov_cli/runners/__init__.py
@@ -1,0 +1,30 @@
+import logging
+
+from codecov_cli.runners.python_standard_runner import PythonStandardRunner
+from codecov_cli.runners.types import LabelAnalysisRunnerInterface
+
+logger = logging.getLogger("codecovcli")
+
+
+class UnableToFindRunner(Exception):
+    pass
+
+
+def _load_runner_from_yaml() -> LabelAnalysisRunnerInterface:
+    raise NotImplementedError()
+
+
+def get_runner(cli_config, runner_name) -> LabelAnalysisRunnerInterface:
+    if runner_name == "python":
+        return PythonStandardRunner()
+    logger.debug(
+        f"Trying to load runner {runner_name}",
+        extra=dict(
+            extra_log_attributes=dict(
+                available_runners=cli_config.get("runners", {}).keys()
+            )
+        ),
+    )
+    if cli_config and runner_name in cli_config.get("runners", {}):
+        return _load_runner_from_yaml(cli_config["runners"][runner_name])
+    raise UnableToFindRunner(f"Can't find runner {runner_name}")

--- a/codecov_cli/runners/python_standard_runner.py
+++ b/codecov_cli/runners/python_standard_runner.py
@@ -1,0 +1,62 @@
+import logging
+import subprocess
+
+from codecov_cli.runners.types import (
+    LabelAnalysisRequestResult,
+    LabelAnalysisRunnerInterface,
+)
+
+logger = logging.getLogger("codecovcli")
+
+
+class PythonStandardRunner(LabelAnalysisRunnerInterface):
+    def collect_tests(self):
+        return [
+            x
+            for x in subprocess.run(
+                ["python", "-m", "pytest", "-q", "--collect-only"],
+                capture_output=True,
+                check=True,
+            )
+            .stdout.decode()
+            .split()
+            if "::" in x
+        ]
+
+    def process_labelanalysis_result(self, result: LabelAnalysisRequestResult):
+        command_array = ["python", "-m", "pytest", "--cov=./", "--cov-context=test"]
+        logger.info(
+            "Received information about tests to run",
+            extra=dict(
+                extra_log_attributes=dict(
+                    absent_labels=len(result["absent_labels"] or []),
+                    present_diff_labels=len(result["present_diff_labels"] or []),
+                    global_level_labels=len(result["global_level_labels"] or []),
+                    present_report_labels=len(result["present_report_labels"] or []),
+                )
+            ),
+        )
+        all_labels = (
+            result["absent_labels"]
+            + result["present_diff_labels"]
+            + result["global_level_labels"]
+        )
+        skipped_tests = set(result["present_report_labels"]) - set(all_labels)
+        if skipped_tests:
+            logger.info(
+                "Some tests are being skipped",
+                extra=dict(
+                    extra_log_attributes=dict(skipped_tests=sorted(skipped_tests))
+                ),
+            )
+        all_labels = set(all_labels)
+        all_labels = [x.rsplit("[", 1)[0] if "[" in x else x for x in all_labels]
+        # Not safe from the customer perspective, in general, probably.
+        # This is just to check it working
+        command_array.extend(all_labels)
+        logger.info("Running tests")
+        logger.debug(
+            "Pytest command",
+            extra=dict(extra_log_attributes=dict(command_array=command_array)),
+        )
+        subprocess.run(command_array, check=True)

--- a/codecov_cli/runners/types.py
+++ b/codecov_cli/runners/types.py
@@ -1,0 +1,16 @@
+from typing import List, TypedDict
+
+
+class LabelAnalysisRequestResult(TypedDict):
+    present_report_labels: List[str]
+    absent_labels: List[str]
+    present_diff_labels: List[str]
+    global_level_labels: List[str]
+
+
+class LabelAnalysisRunnerInterface(object):
+    def collect_tests(self) -> List[str]:
+        raise NotImplementedError()
+
+    def process_labelanalysis_result(self, result: LabelAnalysisRequestResult):
+        raise NotImplementedError()

--- a/tests/factory.py
+++ b/tests/factory.py
@@ -1,8 +1,9 @@
-from typing import Optional
+from typing import List, Optional
 
 from codecov_cli.fallbacks import FallbackFieldEnum
 from codecov_cli.helpers.ci_adapters.base import CIAdapterBase
 from codecov_cli.helpers.versioning_systems import VersioningSystemInterface
+from codecov_cli.runners.types import LabelAnalysisRunnerInterface
 
 
 class FakeProvider(CIAdapterBase):
@@ -71,3 +72,15 @@ class FakeVersioningSystem(VersioningSystemInterface):
 
     def get_fallback_value(self, fallback_field: FallbackFieldEnum) -> Optional[str]:
         return self.values_dict[fallback_field]
+
+
+class FakeRunner(LabelAnalysisRunnerInterface):
+    def __init__(self, collect_tests_response: List[str]) -> None:
+        super().__init__()
+        self.collect_tests_response = collect_tests_response
+
+    def collect_tests(self) -> List[str]:
+        return self.collect_tests_response
+
+    def process_labelanalysis_result(self, result):
+        return "I ran tests :D"

--- a/tests/runners/test_python_standard_runner.py
+++ b/tests/runners/test_python_standard_runner.py
@@ -1,0 +1,57 @@
+from unittest.mock import MagicMock, patch
+
+from codecov_cli.runners.python_standard_runner import PythonStandardRunner
+
+
+class TestPythonStandardRunner(object):
+    runner = PythonStandardRunner()
+
+    @patch("codecov_cli.runners.python_standard_runner.subprocess.run")
+    def test_collect_tests(self, mock_run):
+        collected_test_list = [
+            "tests/services/upload/test_upload_collector.py::test_fix_go_files"
+            "tests/services/upload/test_upload_collector.py::test_fix_php_files"
+            "tests/services/upload/test_upload_collector.py::test_fix_for_cpp_swift_vala"
+            "tests/services/upload/test_upload_service.py::test_do_upload_logic_happy_path_legacy_uploader"
+            "tests/services/upload/test_upload_service.py::test_do_upload_logic_happy_path"
+            "tests/services/upload/test_upload_service.py::test_do_upload_logic_dry_run"
+            "tests/services/upload/test_upload_service.py::test_do_upload_logic_verbose"
+        ]
+        mock_stdout = MagicMock()
+        mock_stdout.configure_mock(
+            **{"stdout.decode.return_value": "\n".join(collected_test_list)}
+        )
+        mock_run.return_value = mock_stdout
+        collected_tests_from_runner = self.runner.collect_tests()
+        assert collected_tests_from_runner == collected_test_list
+        mock_run.assert_called_with(
+            ["python", "-m", "pytest", "-q", "--collect-only"],
+            capture_output=True,
+            check=True,
+        )
+
+    @patch("codecov_cli.runners.python_standard_runner.subprocess.run")
+    def test_process_label_analysis_result(self, mock_run):
+        label_analysis_result = {
+            "present_report_labels": ["test_present"],
+            "absent_labels": ["test_absent"],
+            "present_diff_labels": ["test_in_diff"],
+            "global_level_labels": ["test_global"],
+        }
+        self.runner.process_labelanalysis_result(label_analysis_result)
+        args, kwargs = mock_run.call_args
+        assert kwargs == {"check": True}
+        assert isinstance(args[0], list)
+        actual_command = args[0]
+        assert actual_command[:5] == [
+            "python",
+            "-m",
+            "pytest",
+            "--cov=./",
+            "--cov-context=test",
+        ]
+        assert sorted(actual_command[5:]) == [
+            "test_absent",
+            "test_global",
+            "test_in_diff",
+        ]

--- a/tests/runners/test_runners.py
+++ b/tests/runners/test_runners.py
@@ -1,0 +1,17 @@
+from unittest.mock import patch
+
+from codecov_cli.runners import get_runner
+from codecov_cli.runners.python_standard_runner import PythonStandardRunner
+
+
+class TestRunners(object):
+    def test_get_standard_runners(self):
+        assert isinstance(get_runner({}, "python"), PythonStandardRunner)
+        # TODO: Extend with other standard runners once we create them (e.g. JS)
+
+    @patch("codecov_cli.runners._load_runner_from_yaml")
+    def test_get_runner_from_yaml(self, mock_load_runner):
+        config = {"runners": {"my_runner": {"path": "path_to_my_runner"}}}
+        mock_load_runner.return_value = "MyRunner()"
+        assert get_runner(config, "my_runner") == "MyRunner()"
+        mock_load_runner.assert_called_with({"path": "path_to_my_runner"})


### PR DESCRIPTION
Label analysis will eventually support multiple languages, testing frameworks, etc. For that we will need different runners. Currently we only have `PythonStandardRunner`, and that was hard-coded.

The changes here scaffold a runner system that is similar to the plugin system for upload. We can extend it and eventually let users have their own runners. Letting users have their own runners feels particularly important from a safety pov, users can be certain that the runner is safe to use because they created it. But of course we also need to provide useful runners for the broad cases. It will be easier for uses to trust our runners once the CLI goes open source.

For context, a runner the piece of code that does 2 things:
1. Collects tests from the test_suite
2. Executes the tests that label analysis receives back as being the tests we should run