### PR TITLE
Add options to PythonStandardRunner and make it safer

### DIFF
--- a/codecov_cli/runners/__init__.py
+++ b/codecov_cli/runners/__init__.py
@@ -16,7 +16,8 @@ def _load_runner_from_yaml() -> LabelAnalysisRunnerInterface:
 
 def get_runner(cli_config, runner_name) -> LabelAnalysisRunnerInterface:
     if runner_name == "python":
-        return PythonStandardRunner()
+        config_params = cli_config.get("runners", {}).get("python", {})
+        return PythonStandardRunner(config_params)
     logger.debug(
         f"Trying to load runner {runner_name}",
         extra=dict(

--- a/codecov_cli/runners/python_standard_runner.py
+++ b/codecov_cli/runners/python_standard_runner.py
@@ -1,5 +1,12 @@
 import logging
 import subprocess
+from contextlib import redirect_stdout
+from io import StringIO
+from os import getcwd
+from sys import path
+from typing import List, TypedDict
+
+import pytest
 
 from codecov_cli.runners.types import (
     LabelAnalysisRequestResult,
@@ -9,22 +16,72 @@ from codecov_cli.runners.types import (
 logger = logging.getLogger("codecovcli")
 
 
+class PythonStandardRunnerConfigParams(TypedDict):
+    collect_tests_options: List[str]
+    # include_dirs is to account for the difference described in
+    # https://docs.pytest.org/en/7.1.x/how-to/usage.html#calling-pytest-through-python-m-pytest
+    include_curr_dir: bool
+
+
+def _include_curr_dir(method):
+    def call_method(self, *args, **kwargs):
+        include_curr_dir = self.params["include_curr_dir"]
+        curr_dir = getcwd()
+        if include_curr_dir:
+            path.append(curr_dir)
+        result = method(self, *args, **kwargs)
+        if include_curr_dir:
+            path.remove(curr_dir)
+        return result
+
+    return call_method
+
+
 class PythonStandardRunner(LabelAnalysisRunnerInterface):
+    def __init__(self, config_params: PythonStandardRunnerConfigParams = None) -> None:
+        super().__init__()
+        default_config: PythonStandardRunnerConfigParams = {
+            "collect_tests_options": [],
+            "include_curr_dir": False,
+        }
+        if config_params is None:
+            config_params = PythonStandardRunnerConfigParams()
+        self.params = {**default_config, **config_params}
+
+    @_include_curr_dir
+    def _execute_pytest(self, pytest_args: List[str]) -> str:
+        with StringIO() as fd:
+            with redirect_stdout(fd):
+                result = pytest.main(pytest_args)
+            output = fd.getvalue()
+            if result != pytest.ExitCode.OK and result != 0:
+                logger.error(
+                    "Pytest did not run correctly",
+                    extra=dict(
+                        extra_log_attributes=dict(exit_code=result, output=output)
+                    ),
+                )
+                raise Exception("Pytest did not run correctly")
+        return output
+
     def collect_tests(self):
-        return [
-            x
-            for x in subprocess.run(
-                ["python", "-m", "pytest", "-q", "--collect-only"],
-                capture_output=True,
-                check=True,
-            )
-            .stdout.decode()
-            .split()
-            if "::" in x
-        ]
+        default_options = ["-q", "--collect-only"]
+        extra_args = self.params["collect_tests_options"]
+        options_to_use = default_options + extra_args
+        logger.debug(
+            "Collecting tests",
+            extra=dict(
+                extra_log_attributes=dict(options=options_to_use),
+            ),
+        )
+
+        output = self._execute_pytest(options_to_use)
+        lines = output.split()
+        test_names = list(line for line in lines if "::" in line)
+        return test_names
 
     def process_labelanalysis_result(self, result: LabelAnalysisRequestResult):
-        command_array = ["python", "-m", "pytest", "--cov=./", "--cov-context=test"]
+        default_options = ["--cov=./", "--cov-context=test"]
         logger.info(
             "Received information about tests to run",
             extra=dict(
@@ -53,10 +110,12 @@ class PythonStandardRunner(LabelAnalysisRunnerInterface):
         all_labels = [x.rsplit("[", 1)[0] if "[" in x else x for x in all_labels]
         # Not safe from the customer perspective, in general, probably.
         # This is just to check it working
-        command_array.extend(all_labels)
+        command_array = default_options + all_labels
         logger.info("Running tests")
         logger.debug(
             "Pytest command",
             extra=dict(extra_log_attributes=dict(command_array=command_array)),
         )
-        subprocess.run(command_array, check=True)
+        output = self._execute_pytest(command_array)
+        logger.info("Finished running tests successfully")
+        logger.debug(output)

--- a/tests/runners/test_python_standard_runner.py
+++ b/tests/runners/test_python_standard_runner.py
@@ -1,56 +1,156 @@
+from typing import List
 from unittest.mock import MagicMock, patch
 
-from codecov_cli.runners.python_standard_runner import PythonStandardRunner
+import pytest
+from pytest import ExitCode
+
+from codecov_cli.runners.python_standard_runner import (
+    PythonStandardRunner,
+    PythonStandardRunnerConfigParams,
+)
 
 
 class TestPythonStandardRunner(object):
     runner = PythonStandardRunner()
+    output_noise = "\n\n========================================================== warnings summary ===========================================================\n../codecov-api/venv/lib/python3.9/site-packages/pytest_asyncio/plugin.py:191\n  /Users/giovannimguidini/Projects/GitHub/codecov-api/venv/lib/python3.9/site-packages/pytest_asyncio/plugin.py:191: DeprecationWarning: The 'asyncio_mode' default value will change to 'strict' in future, please explicitly use 'asyncio_mode=strict' or 'asyncio_mode=auto' in pytest configuration file.\n    config.issue_config_time_warning(LEGACY_MODE, stacklevel=2)\n\n-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html\n508 tests collected in 0.26s\n<ExitCode.OK: 0>\n"
 
-    @patch("codecov_cli.runners.python_standard_runner.subprocess.run")
-    def test_collect_tests(self, mock_run):
+    def test_init_with_params(self):
+        assert self.runner.params == PythonStandardRunnerConfigParams(
+            collect_tests_options=[], include_curr_dir=False
+        )
+        config_params = PythonStandardRunnerConfigParams(
+            collect_tests_options=["--option=value", "-option"], include_curr_dir=True
+        )
+        runner_with_params = PythonStandardRunner(config_params)
+        assert runner_with_params.params == config_params
+
+    @patch("codecov_cli.runners.python_standard_runner.path")
+    @patch("codecov_cli.runners.python_standard_runner.StringIO")
+    @patch("codecov_cli.runners.python_standard_runner.pytest")
+    def test_execute_pytest(self, mock_pytest, mock_stringio, mock_sys_path):
+        output = "Output in stdout"
+        mock_getvalue = MagicMock(return_value=output)
+        mock_stringio.return_value.__enter__.return_value.getvalue = mock_getvalue
+        mock_pytest.main.return_value = ExitCode.OK
+
+        result = self.runner._execute_pytest(["--option", "--ignore=batata"])
+        mock_pytest.main.assert_called_with(["--option", "--ignore=batata"])
+        mock_stringio.assert_called()
+        mock_getvalue.assert_called()
+        mock_sys_path.append.assert_not_called()
+        assert result == output
+
+    @patch("codecov_cli.runners.python_standard_runner.path")
+    @patch("codecov_cli.runners.python_standard_runner.StringIO")
+    @patch("codecov_cli.runners.python_standard_runner.pytest")
+    def test_execute_pytest_fail(self, mock_pytest, mock_stringio, mock_sys_path):
+        output = "Output in stdout"
+        mock_getvalue = MagicMock(return_value=output)
+        mock_stringio.return_value.__enter__.return_value.getvalue = mock_getvalue
+        mock_pytest.main.return_value = ExitCode.INTERNAL_ERROR
+
+        with pytest.raises(Exception) as exp:
+            result = self.runner._execute_pytest(["--option", "--ignore=batata"])
+        assert str(exp.value) == "Pytest did not run correctly"
+        mock_pytest.main.assert_called_with(["--option", "--ignore=batata"])
+        mock_stringio.assert_called()
+        mock_getvalue.assert_called()
+        mock_sys_path.append.assert_not_called()
+
+    @patch("codecov_cli.runners.python_standard_runner.getcwd")
+    @patch("codecov_cli.runners.python_standard_runner.path")
+    @patch("codecov_cli.runners.python_standard_runner.StringIO")
+    @patch("codecov_cli.runners.python_standard_runner.pytest")
+    def test_execute_pytest_include_curr_dir(
+        self, mock_pytest, mock_stringio, mock_sys_path, mock_getcwd
+    ):
+        output = "Output in stdout"
+        mock_getcwd.return_value = "current directory"
+        mock_getvalue = MagicMock(return_value=output)
+        mock_stringio.return_value.__enter__.return_value.getvalue = mock_getvalue
+        mock_pytest.main.return_value = ExitCode.OK
+
+        config_params = PythonStandardRunnerConfigParams(include_curr_dir=True)
+        runner = PythonStandardRunner(config_params)
+        result = runner._execute_pytest(["--option", "--ignore=batata"])
+        mock_pytest.main.assert_called_with(["--option", "--ignore=batata"])
+        mock_stringio.assert_called()
+        mock_getvalue.assert_called()
+        mock_sys_path.append.assert_called_with("current directory")
+        mock_sys_path.remove.assert_called_with("current directory")
+        mock_getcwd.assert_called()
+        assert result == output
+
+    @patch("codecov_cli.runners.python_standard_runner.StringIO")
+    @patch("codecov_cli.runners.python_standard_runner.pytest")
+    def test_collect_tests(self, mock_pytest, mock_stringio):
         collected_test_list = [
-            "tests/services/upload/test_upload_collector.py::test_fix_go_files"
-            "tests/services/upload/test_upload_collector.py::test_fix_php_files"
-            "tests/services/upload/test_upload_collector.py::test_fix_for_cpp_swift_vala"
             "tests/services/upload/test_upload_service.py::test_do_upload_logic_happy_path_legacy_uploader"
             "tests/services/upload/test_upload_service.py::test_do_upload_logic_happy_path"
             "tests/services/upload/test_upload_service.py::test_do_upload_logic_dry_run"
             "tests/services/upload/test_upload_service.py::test_do_upload_logic_verbose"
         ]
-        mock_stdout = MagicMock()
-        mock_stdout.configure_mock(
-            **{"stdout.decode.return_value": "\n".join(collected_test_list)}
+        mock_getvalue = MagicMock(
+            return_value="\n".join(collected_test_list + [self.output_noise])
         )
-        mock_run.return_value = mock_stdout
-        collected_tests_from_runner = self.runner.collect_tests()
-        assert collected_tests_from_runner == collected_test_list
-        mock_run.assert_called_with(
-            ["python", "-m", "pytest", "-q", "--collect-only"],
-            capture_output=True,
-            check=True,
-        )
+        mock_stringio.return_value.__enter__.return_value.getvalue = mock_getvalue
+        mock_pytest.main.return_value = ExitCode.OK
 
-    @patch("codecov_cli.runners.python_standard_runner.subprocess.run")
-    def test_process_label_analysis_result(self, mock_run):
+        collected_tests_from_runner = self.runner.collect_tests()
+        mock_pytest.main.assert_called_with(["-q", "--collect-only"])
+        mock_stringio.assert_called()
+        mock_getvalue.assert_called()
+        assert collected_tests_from_runner == collected_test_list
+
+    @patch("codecov_cli.runners.python_standard_runner.StringIO")
+    @patch("codecov_cli.runners.python_standard_runner.pytest")
+    def test_collect_tests_with_options(self, mock_pytest, mock_stringio):
+        collected_test_list = [
+            "tests/services/upload/test_upload_collector.py::test_fix_go_files"
+            "tests/services/upload/test_upload_collector.py::test_fix_php_files"
+        ]
+        mock_getvalue = MagicMock(
+            return_value="\n".join(collected_test_list + [self.output_noise])
+        )
+        mock_stringio.return_value.__enter__.return_value.getvalue = mock_getvalue
+        mock_pytest.main = MagicMock(return_value=ExitCode.OK)
+
+        config_params = PythonStandardRunnerConfigParams(
+            collect_tests_options=["--option=value", "-option"],
+        )
+        runner_with_params = PythonStandardRunner(config_params)
+
+        collected_tests_from_runner = runner_with_params.collect_tests()
+        mock_pytest.main.assert_called_with(
+            ["-q", "--collect-only", "--option=value", "-option"]
+        )
+        mock_stringio.assert_called()
+        mock_getvalue.assert_called()
+        assert collected_tests_from_runner == collected_test_list
+
+    @patch("codecov_cli.runners.python_standard_runner.StringIO")
+    @patch("codecov_cli.runners.python_standard_runner.pytest")
+    def test_process_label_analysis_result(self, mock_pytest, mock_stringio):
         label_analysis_result = {
             "present_report_labels": ["test_present"],
             "absent_labels": ["test_absent"],
             "present_diff_labels": ["test_in_diff"],
             "global_level_labels": ["test_global"],
         }
+        mock_pytest.main.return_value = ExitCode.OK
+
         self.runner.process_labelanalysis_result(label_analysis_result)
-        args, kwargs = mock_run.call_args
-        assert kwargs == {"check": True}
+        mock_stringio.assert_called()
+        mock_pytest.main.assert_called()
+        args, kwargs = mock_pytest.main.call_args
+        assert kwargs == {}
         assert isinstance(args[0], list)
         actual_command = args[0]
-        assert actual_command[:5] == [
-            "python",
-            "-m",
-            "pytest",
+        assert actual_command[:2] == [
             "--cov=./",
             "--cov-context=test",
         ]
-        assert sorted(actual_command[5:]) == [
+        assert sorted(actual_command[2:]) == [
             "test_absent",
             "test_global",
             "test_in_diff",

--- a/tests/runners/test_runners.py
+++ b/tests/runners/test_runners.py
@@ -9,6 +9,14 @@ class TestRunners(object):
         assert isinstance(get_runner({}, "python"), PythonStandardRunner)
         # TODO: Extend with other standard runners once we create them (e.g. JS)
 
+    def test_python_standard_runner_with_options(self):
+        config_params = dict(
+            collect_tests_options=["--option=value", "-option"],
+        )
+        runner_instance = get_runner({"runners": {"python": config_params}}, "python")
+        assert isinstance(runner_instance, PythonStandardRunner)
+        assert runner_instance.params == {**config_params, "include_curr_dir": False}
+
     @patch("codecov_cli.runners._load_runner_from_yaml")
     def test_get_runner_from_yaml(self, mock_load_runner):
         config = {"runners": {"my_runner": {"path": "path_to_my_runner"}}}


### PR DESCRIPTION
* Adds config options to PythonStandardRunner. They can be configured via the yaml that will be used with the CLI. Currently options include only collect options.

* Make the python runner execute pytest directly from script, not from subcommand. To try and make the python runner as safe as possible we are calling pytest directly from the script. Users can still pass in options, but it's less obvious how to get an attack from that. At least you can't specify any command to run.

About the running tests step.
The [documentation](https://docs.pytest.org/en/7.1.x/how-to/usage.html#calling-pytest-from-python-code) says that calling pytest from code directly "acts as if you would call “pytest” from the command line. It will not raise [SystemExit](https://docs.python.org/3/library/exceptions.html#SystemExit) but return the [exit code](https://docs.pytest.org/en/7.1.x/reference/exit-codes.html#exit-codes) instead. You can pass in options and arguments" which _seems_ to be exactly what we want.