### PR TITLE
Don't send unecessary files in static analysis

### DIFF
--- a/codecov_cli/services/staticanalysis/__init__.py
+++ b/codecov_cli/services/staticanalysis/__init__.py
@@ -112,7 +112,7 @@ async def run_analysis_entrypoint(
             limits = httpx.Limits(max_keepalive_connections=3, max_connections=5)
             async with httpx.AsyncClient(limits=limits) as client:
                 all_tasks = []
-                for el in response_json["filepaths"]:
+                for el in files_that_need_upload:
                     all_tasks.append(send_single_upload_put(client, all_data, el))
                     bar.update(1, all_data[el["filepath"]])
                 resps = await asyncio.gather(*all_tasks)

--- a/codecov_cli/services/staticanalysis/types.py
+++ b/codecov_cli/services/staticanalysis/types.py
@@ -1,3 +1,4 @@
+import pathlib
 from dataclasses import dataclass
 from typing import Optional
 
@@ -5,7 +6,7 @@ from typing import Optional
 @dataclass
 class FileAnalysisRequest(object):
     result_filename: str
-    actual_filepath: str
+    actual_filepath: pathlib.Path
 
 
 @dataclass

--- a/requirements.in
+++ b/requirements.in
@@ -2,6 +2,7 @@ click
 pytest
 pytest-cov
 pytest-mock
+pytest-asyncio
 pyyaml
 responses
 httpx

--- a/requirements.txt
+++ b/requirements.txt
@@ -43,8 +43,11 @@ pyparsing==3.0.9
 pytest==7.1.2
     # via
     #   -r requirements.in
+    #   pytest-asyncio
     #   pytest-cov
     #   pytest-mock
+pytest-asyncio==0.21.0
+    # via -r requirements.in
 pytest-cov==3.0.0
     # via -r requirements.in
 pytest-mock==3.8.2

--- a/tests/services/static_analysis/test_analyse_file.py
+++ b/tests/services/static_analysis/test_analyse_file.py
@@ -1,5 +1,6 @@
 import json
 from pathlib import Path
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -40,3 +41,16 @@ def test_sample_analysis(input_filename, output_filename):
     )
     assert res_dict["result"] == expected_result["result"]
     assert res_dict == expected_result
+
+
+@patch("builtins.open")
+@patch("codecov_cli.services.staticanalysis.get_best_analyzer", return_value=None)
+def test_analyse_file_no_analyser(mock_get_analyser, mock_open):
+    fake_contents = MagicMock()
+    file_name = MagicMock(actual_filepath="filepath")
+    mock_open.return_value.read.return_value = fake_contents
+    config = {}
+    res = analyze_file(config, file_name)
+    assert res == None
+    assert mock_open.called_with("filepath", "rb")
+    assert mock_get_analyser.called_with(file_name, fake_contents)

--- a/tests/services/static_analysis/test_static_analysis_service.py
+++ b/tests/services/static_analysis/test_static_analysis_service.py
@@ -1,0 +1,120 @@
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+import responses
+from responses import matchers
+
+from codecov_cli.services.staticanalysis import run_analysis_entrypoint
+from codecov_cli.services.staticanalysis.types import FileAnalysisRequest
+
+
+class TestStaticAnalysisService:
+    @pytest.mark.asyncio
+    @patch("codecov_cli.services.staticanalysis.select_file_finder")
+    @patch("codecov_cli.services.staticanalysis.send_single_upload_put")
+    async def test_static_analysis_service(
+        self, mock_send_upload_put, mock_file_finder
+    ):
+        files_found = map(
+            lambda filename: FileAnalysisRequest(str(filename), Path(filename)),
+            [
+                "samples/inputs/sample_001.py",
+                "samples/inputs/sample_002.py",
+            ],
+        )
+        mock_file_finder.return_value.find_files = MagicMock(return_value=files_found)
+        with responses.RequestsMock() as rsps:
+            rsps.add(
+                responses.POST,
+                "https://api.codecov.io/staticanalysis/analyses",
+                json={
+                    "filepaths": [
+                        {
+                            "state": "created",
+                            "filepath": "samples/inputs/sample_001.py",
+                            "raw_upload_location": "some URL",
+                        },
+                        {
+                            "state": "valid",
+                            "filepath": "samples/inputs/sample_002.py",
+                            "raw_upload_location": "some URL",
+                        },
+                    ]
+                },
+                status=200,
+                match=[
+                    matchers.header_matcher({"Authorization": "Repotoken STATIC_TOKEN"})
+                ],
+            )
+            await run_analysis_entrypoint(
+                config={},
+                folder=".",
+                numberprocesses=1,
+                pattern="*.py",
+                token="STATIC_TOKEN",
+                commit="COMMIT",
+                should_force=False,
+                folders_to_exclude=[],
+            )
+        mock_file_finder.assert_called_with({})
+        mock_file_finder.return_value.find_files.assert_called()
+        assert mock_send_upload_put.call_count == 1
+        args, _ = mock_send_upload_put.call_args
+        assert args[2] == {
+            "state": "created",
+            "filepath": "samples/inputs/sample_001.py",
+            "raw_upload_location": "some URL",
+        }
+
+    @pytest.mark.asyncio
+    @patch("codecov_cli.services.staticanalysis.select_file_finder")
+    @patch("codecov_cli.services.staticanalysis.send_single_upload_put")
+    async def test_static_analysis_service_should_force_option(
+        self, mock_send_upload_put, mock_file_finder
+    ):
+        files_found = map(
+            lambda filename: FileAnalysisRequest(str(filename), Path(filename)),
+            [
+                "samples/inputs/sample_001.py",
+                "samples/inputs/sample_002.py",
+            ],
+        )
+        mock_file_finder.return_value.find_files = MagicMock(return_value=files_found)
+        with responses.RequestsMock() as rsps:
+            rsps.add(
+                responses.POST,
+                "https://api.codecov.io/staticanalysis/analyses",
+                json={
+                    "filepaths": [
+                        {
+                            "state": "created",
+                            "filepath": "samples/inputs/sample_001.py",
+                            "raw_upload_location": "some URL",
+                        },
+                        {
+                            "state": "valid",
+                            "filepath": "samples/inputs/sample_002.py",
+                            "raw_upload_location": "some URL",
+                        },
+                    ]
+                },
+                status=200,
+                match=[
+                    matchers.header_matcher({"Authorization": "Repotoken STATIC_TOKEN"})
+                ],
+            )
+            await run_analysis_entrypoint(
+                config={},
+                folder=".",
+                numberprocesses=1,
+                pattern="*.py",
+                token="STATIC_TOKEN",
+                commit="COMMIT",
+                should_force=True,
+                folders_to_exclude=[],
+            )
+        mock_file_finder.assert_called_with({})
+        mock_file_finder.return_value.find_files.assert_called()
+        assert mock_send_upload_put.call_count == 2
+        args, _ = mock_send_upload_put.call_args


### PR DESCRIPTION
You can see that we were already calculating `files_that_need_upload` in static analysis but still iterating over all the files in the response from codecov. This means we were effectively uploading all files everytime. This is unecessary and takes a long time and consumes more data than we need. Plus it was causing issues with the TTL of the pre-signed PUT as well.

The fix is very obvious, just iterate over the files that actually need to be updated.

I also took this opportunity to add some tests to static analysis (coverage is terrible in this command) THe new requirement is to test the async function in the service. Maybe it should be in a dedicated requirements.txt inside `tests`?...

For the type change, looking at the `FileFinder.find_files` implementation ([here](https://github.com/codecov/codecov-cli/blob/0aafd155d242ee4844bf98e3410459c84fa8817d/codecov_cli/services/staticanalysis/finders.py#L23)) you can see it was already returning a Path and a str, not 2 str. Justing making the type annotation match the implementation.