### PR TITLE
Let users pass config to CLI

### DIFF
--- a/codecov_cli/helpers/config.py
+++ b/codecov_cli/helpers/config.py
@@ -1,0 +1,17 @@
+import logging
+import pathlib
+
+import yaml
+
+logger = logging.getLogger("codecovcli")
+
+
+def load_cli_config(codecov_yml_path: pathlib.Path):
+    if codecov_yml_path.exists() and codecov_yml_path.is_file():
+        logger.debug(f"Loading config from {codecov_yml_path}")
+        with open(codecov_yml_path, "r") as file_stream:
+            return yaml.safe_load(file_stream.read())
+    logger.warning(
+        f"File {codecov_yml_path} not found, or is not a file. Ignoring config."
+    )
+    return None

--- a/codecov_cli/main.py
+++ b/codecov_cli/main.py
@@ -3,7 +3,6 @@ import pathlib
 import typing
 
 import click
-import yaml
 
 from codecov_cli.commands.base_picking import pr_base_picking
 from codecov_cli.commands.commit import create_commit
@@ -14,6 +13,7 @@ from codecov_cli.commands.report import create_report
 from codecov_cli.commands.staticanalysis import static_analysis
 from codecov_cli.commands.upload import do_upload
 from codecov_cli.helpers.ci_adapters import get_ci_adapter, get_ci_providers_list
+from codecov_cli.helpers.config import load_cli_config
 from codecov_cli.helpers.logging_utils import configure_logger
 from codecov_cli.helpers.versioning_systems import get_versioning_system
 
@@ -46,13 +46,9 @@ def cli(
     ctx.obj["ci_adapter"] = get_ci_adapter(auto_load_params_from)
     ctx.obj["versioning_system"] = get_versioning_system()
     ctx.obj["codecov_yaml"] = (
-        yaml.safe_load(codecov_yml_path.read())
-        if codecov_yml_path is not None
-        else None
+        load_cli_config(codecov_yml_path) if codecov_yml_path else None
     )
-    if ctx.obj["codecov_yaml"]:
-        logger.debug(f"Using codecov_yaml from {codecov_yml_path}")
-    else:
+    if ctx.obj["codecov_yaml"] is None:
         logger.debug("No codecov_yaml found")
 
 

--- a/samples/example_cli_config.yml
+++ b/samples/example_cli_config.yml
@@ -1,0 +1,5 @@
+runners:
+  python:
+    collect_tests_options:
+      - --ignore
+      - batata

--- a/tests/helpers/test_config.py
+++ b/tests/helpers/test_config.py
@@ -1,0 +1,23 @@
+import pathlib
+
+from codecov_cli.helpers.config import load_cli_config
+
+
+def test_load_config(mocker):
+    path = pathlib.Path("samples/example_cli_config.yml")
+    result = load_cli_config(path)
+    assert result == {
+        "runners": {"python": {"collect_tests_options": ["--ignore", "batata"]}}
+    }
+
+
+def test_load_config_doesnt_exist(mocker):
+    path = pathlib.Path("doesnt/exist")
+    result = load_cli_config(path)
+    assert result == None
+
+
+def test_load_config_not_file(mocker):
+    path = pathlib.Path("samples/")
+    result = load_cli_config(path)
+    assert result == None


### PR DESCRIPTION
We have an option in the cli to allow users to pass config to it. Config controls things like plugins and runners.

Until this point we didn't have to use it, and it was actually broken. The issue was that `yaml.safe_load` expects a strem (e.g. file contents), not the file name. So this fixes that issue, and also adds test to make sure the logging is correct.


I decided to move the loading of the config to a helper function to make it easier to test.
Turns out you can't just explicitly call `cli` function because it's wrapped in so much click stuff.
Having it in a separate place makes it easier to test the actual config too.