### PR TITLE
Make PythonStandardRunner include curr dir by default

### DIFF
--- a/codecov_cli/commands/labelanalysis.py
+++ b/codecov_cli/commands/labelanalysis.py
@@ -56,7 +56,10 @@ def label_analysis(
     codecov_yaml = ctx.obj["codecov_yaml"] or {}
     cli_config = codecov_yaml.get("cli", {})
     runner = get_runner(cli_config, runner_name)
-    logger.debug(f"Selected runner: {runner}")
+    logger.debug(
+        f"Selected runner: {runner}",
+        extra=dict(extra_log_attributes=dict(config=runner.params)),
+    )
     requested_labels = runner.collect_tests()
     logger.info(f"Collected {len(requested_labels)} tests")
     logger.debug(

--- a/codecov_cli/runners/python_standard_runner.py
+++ b/codecov_cli/runners/python_standard_runner.py
@@ -42,7 +42,7 @@ class PythonStandardRunner(LabelAnalysisRunnerInterface):
         super().__init__()
         default_config: PythonStandardRunnerConfigParams = {
             "collect_tests_options": [],
-            "include_curr_dir": False,
+            "include_curr_dir": True,
         }
         if config_params is None:
             config_params = PythonStandardRunnerConfigParams()

--- a/codecov_cli/runners/types.py
+++ b/codecov_cli/runners/types.py
@@ -9,6 +9,8 @@ class LabelAnalysisRequestResult(TypedDict):
 
 
 class LabelAnalysisRunnerInterface(object):
+    params = None
+
     def collect_tests(self) -> List[str]:
         raise NotImplementedError()
 

--- a/tests/runners/test_runners.py
+++ b/tests/runners/test_runners.py
@@ -17,7 +17,7 @@ class TestRunners(object):
         )
         runner_instance = get_runner({"runners": {"python": config_params}}, "python")
         assert isinstance(runner_instance, PythonStandardRunner)
-        assert runner_instance.params == {**config_params, "include_curr_dir": False}
+        assert runner_instance.params == {**config_params, "include_curr_dir": True}
 
     def test_get_dan_runner_with_params(self):
         config = {


### PR DESCRIPTION
Turns out that when you package the CLI in PyInstaller, if you don't have the curr dir in PATH there's a high probability that pytest will fail because of the pytest plugins (it won't find them)

So it's better to add the current dir by default to avoid issues.

On top of that also adding `params` in the runner interface so we can log the params of the selected runner.