### PR TITLE
Add --version option to CLI

### DIFF
--- a/codecov_cli/main.py
+++ b/codecov_cli/main.py
@@ -35,6 +35,7 @@ logger = logging.getLogger("codecovcli")
 @click.option("--enterprise-url")
 @click.option("-v", "--verbose", "verbose", help="Use verbose logging", is_flag=True)
 @click.pass_context
+@click.version_option()
 def cli(
     ctx: click.Context,
     auto_load_params_from: typing.Optional[str],

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import Extension, find_packages, setup
 
 setup(
     name="codecov-cli",
-    version="0.1.0",
+    version="0.1.4",
     packages=find_packages(exclude=["contrib", "docs", "tests*"]),
     description="Codecov Command Line Interface",
     long_description="",


### PR DESCRIPTION
Adds a `--version` option that displays the version in `setup.py`.
This will help us cache the CLI by version in github actions and is usually expected to exist in CLI tools.

Example:
```bash
$ codecovcli --version
codecovcli, version 0.1.4
```

Also bumping version number to the current version