### PR TITLE
Use PyPi

### DIFF
--- a/.github/workflows/release_flow.yml
+++ b/.github/workflows/release_flow.yml
@@ -9,8 +9,36 @@ on:
       - 'v*' # Runs only for tags that start with v (new versions)
 
 jobs:
+  build_and_publish:
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write # This is required for requesting the JWT
+      contents: read  # This is required for actions/checkout
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        submodules: true
+    - name: Set up Python 3.10
+      uses: actions/setup-python@v4
+      with:
+        python-version: "3.10" 
+    - name: Install dependencies
+      run: |
+        pip install -r requirements.txt  
+        python setup.py build
+        python setup.py develop
+    - name: Build distributions for different platforms
+      run: |
+        pip install wheel
+        python setup.py sdist bdist_wheel --plat-name=manylinux2014_x86_64
+        python setup.py bdist_wheel --plat-name=macosx-12.6-x86_64
+        python setup.py bdist_wheel --plat-name=win_amd64
+    - name: Publish package to PyPi
+      uses: pypa/gh-action-pypi-publish@release/v1
+
   changelog:
     runs-on: ubuntu-latest
+    needs: build_and_publish
     steps:
       - name: "Generate release changelog"
         uses: heinrichreimer/github-changelog-generator-action@v2.3

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,2 @@
+include languages/treesitterjavascript/src/tree_sitter/parser.h
+include languages/treesitterpython/src/tree_sitter/parser.h

--- a/setup.py
+++ b/setup.py
@@ -1,13 +1,20 @@
 from platform import system
+from os import path
 
 from setuptools import Extension, find_packages, setup
+
+here = path.abspath(path.dirname(__file__))
+
+with open(path.join(here, "README.md"), encoding="utf-8") as f:
+    long_description = f.read()
 
 setup(
     name="codecov-cli",
     version="0.1.4",
     packages=find_packages(exclude=["contrib", "docs", "tests*"]),
     description="Codecov Command Line Interface",
-    long_description="",
+    long_description=long_description,
+    long_description_content_type='text/markdown',
     author="Codecov",
     author_email="support@codecov.io",
     install_requires=["click", "requests", "PyYAML", "tree_sitter", "httpx"],
@@ -29,6 +36,8 @@ setup(
             include_dirs=[
                 "languages/treesitterpython/src",
                 "languages/treesitterjavascript/src",
+                "languages/treesitterjavascript/src/tree_sitter",
+                "languages/treesitterpython/src/tree_sitter",
             ],
             extra_compile_args=(
                 ["-Wno-unused-variable"] if system() != "Windows" else None


### PR DESCRIPTION
add c header files to be recognized in the build process, add a step to build and publish to pypi
the manifest file helps with including the c header files we have. Without this the build step will be failing complaining about not found files/headers 
 We're building different wheels for each platform, as we have C extensions, it is preferable to have platform-specific wheels instead of a universal one as mentioned here https://pythonwheels.com/ 
 This has been tested in this PR https://github.com/codecov/codecov-cli/pull/135 
 You can see the last commit uploads to testPyPi, https://test.pypi.org/manage/project/codecov-cli/release/0.1.25/ 

when creating the source files and wheels, they are saved in the dist folder. Any other file found there generates an error when uploading to pypi because pypi only accepts a specific set of files. That being said, the pyinstaller process generates executable files in the dist folder, so we have to publish our package to pypi first, then continue on with the pyinstaller process. That's why the changelog step depends on the build and publish step to pypi 

when publishing to PyPi, you need to increase the version in setup.py, you want that to be aligned with the other releases there but also not duplicated. Then create a new tag to trigger the workflow, and to create github releases with that tag name. If you think there is a better approach, please let me know 

 Ticket: [CODE-2638](https://codecovio.atlassian.net/browse/CODE-2638?atlOrigin=eyJpIjoiMDAzNDA1ZTMyZTFhNGU0ZTg3ODE1YTY5MmU5MTZkZmIiLCJwIjoiaiJ9)


[CODE-2638]: https://codecovio.atlassian.net/browse/CODE-2638?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ