### PR TITLE
Run pytest in a subprocess using multiprocessing

### DIFF
--- a/tests/runners/test_python_standard_runner.py
+++ b/tests/runners/test_python_standard_runner.py
@@ -1,5 +1,5 @@
 from typing import List
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock, call, patch
 
 import pytest
 from pytest import ExitCode
@@ -7,7 +7,22 @@ from pytest import ExitCode
 from codecov_cli.runners.python_standard_runner import (
     PythonStandardRunner,
     PythonStandardRunnerConfigParams,
+    _execute_pytest_subprocess,
 )
+
+
+@patch("codecov_cli.runners.python_standard_runner.pytest")
+def test_execute_pytest_subprocess(mock_pytest, mocker):
+    def side_effect(*args, **kwargs):
+        print("Pytest output")
+        return ExitCode.OK
+
+    mock_pytest.main.side_effect = side_effect
+    mock_queue = MagicMock()
+    _execute_pytest_subprocess(["pytest", "args"], mock_queue)
+    mock_pytest.main.assert_called_with(["pytest", "args"])
+    assert mock_queue.put.call_count == 2
+    mock_queue.put.assert_has_calls([call("Pytest output\n"), call(ExitCode.OK)])
 
 
 class TestPythonStandardRunner(object):
@@ -29,22 +44,25 @@ class TestPythonStandardRunner(object):
         return_value="current directory",
     )
     @patch("codecov_cli.runners.python_standard_runner.path")
-    @patch("codecov_cli.runners.python_standard_runner.StringIO")
-    @patch("codecov_cli.runners.python_standard_runner.pytest")
-    def test_execute_pytest(
-        self, mock_pytest, mock_stringio, mock_sys_path, mock_getcwd
-    ):
+    @patch("codecov_cli.runners.python_standard_runner.get_context")
+    def test_execute_pytest(self, mock_get_context, mock_sys_path, mock_getcwd):
         output = "Output in stdout"
-        mock_getvalue = MagicMock(return_value=output)
-        mock_stringio.return_value.__enter__.return_value.getvalue = mock_getvalue
-        mock_pytest.main.return_value = ExitCode.OK
+        mock_queue = MagicMock()
+        mock_queue.get.side_effect = [output, ExitCode.OK]
+        mock_process = MagicMock()
+        mock_process.exitcode = 0
+        mock_get_context.return_value.Queue.return_value = mock_queue
+        mock_get_context.return_value.Process.return_value = mock_process
 
         result = self.runner._execute_pytest(["--option", "--ignore=batata"])
-        mock_pytest.main.assert_called_with(["--option", "--ignore=batata"])
-        mock_stringio.assert_called()
-        mock_getvalue.assert_called()
+        mock_get_context.return_value.Queue.assert_called_with(2)
+        mock_get_context.return_value.Process.assert_called_with(
+            target=_execute_pytest_subprocess,
+            args=[["--option", "--ignore=batata"], mock_queue],
+        )
         mock_sys_path.append.assert_called_with("current directory")
         mock_sys_path.remove.assert_called_with("current directory")
+        assert mock_queue.get.call_count == 2
         assert result == output
 
     @patch(
@@ -52,80 +70,81 @@ class TestPythonStandardRunner(object):
         return_value="current directory",
     )
     @patch("codecov_cli.runners.python_standard_runner.path")
-    @patch("codecov_cli.runners.python_standard_runner.StringIO")
-    @patch("codecov_cli.runners.python_standard_runner.pytest")
-    def test_execute_pytest_fail(
-        self, mock_pytest, mock_stringio, mock_sys_path, mock_getcwd
-    ):
+    @patch("codecov_cli.runners.python_standard_runner.get_context")
+    def test_execute_pytest_fail(self, mock_get_context, mock_sys_path, mock_getcwd):
         output = "Output in stdout"
-        mock_getvalue = MagicMock(return_value=output)
-        mock_stringio.return_value.__enter__.return_value.getvalue = mock_getvalue
-        mock_pytest.main.return_value = ExitCode.INTERNAL_ERROR
+        mock_queue = MagicMock()
+        mock_queue.get.side_effect = [output, ExitCode.INTERNAL_ERROR]
+        mock_process = MagicMock()
+        mock_process.exitcode = 0
+        mock_get_context.return_value.Queue.return_value = mock_queue
+        mock_get_context.return_value.Process.return_value = mock_process
 
         with pytest.raises(Exception) as exp:
-            result = self.runner._execute_pytest(["--option", "--ignore=batata"])
+            _ = self.runner._execute_pytest(["--option", "--ignore=batata"])
         assert str(exp.value) == "Pytest did not run correctly"
-        mock_pytest.main.assert_called_with(["--option", "--ignore=batata"])
-        mock_stringio.assert_called()
-        mock_getvalue.assert_called()
+        mock_get_context.return_value.Queue.assert_called_with(2)
+        mock_get_context.return_value.Process.assert_called_with(
+            target=_execute_pytest_subprocess,
+            args=[["--option", "--ignore=batata"], mock_queue],
+        )
         mock_sys_path.append.assert_called_with("current directory")
 
     @patch("codecov_cli.runners.python_standard_runner.getcwd")
     @patch("codecov_cli.runners.python_standard_runner.path")
-    @patch("codecov_cli.runners.python_standard_runner.StringIO")
-    @patch("codecov_cli.runners.python_standard_runner.pytest")
+    @patch("codecov_cli.runners.python_standard_runner.get_context")
     def test_execute_pytest_NOT_include_curr_dir(
-        self, mock_pytest, mock_stringio, mock_sys_path, mock_getcwd
+        self, mock_get_context, mock_sys_path, mock_getcwd
     ):
         output = "Output in stdout"
-        mock_getcwd.return_value = "current directory"
-        mock_getvalue = MagicMock(return_value=output)
-        mock_stringio.return_value.__enter__.return_value.getvalue = mock_getvalue
-        mock_pytest.main.return_value = ExitCode.OK
+        mock_queue = MagicMock()
+        mock_queue.get.side_effect = [output, ExitCode.OK]
+        mock_process = MagicMock()
+        mock_process.exitcode = 0
+        mock_get_context.return_value.Queue.return_value = mock_queue
+        mock_get_context.return_value.Process.return_value = mock_process
 
         config_params = PythonStandardRunnerConfigParams(include_curr_dir=False)
-        runner = PythonStandardRunner(config_params)
+        runner = PythonStandardRunner(config_params=config_params)
         result = runner._execute_pytest(["--option", "--ignore=batata"])
-        mock_pytest.main.assert_called_with(["--option", "--ignore=batata"])
-        mock_stringio.assert_called()
-        mock_getvalue.assert_called()
+        mock_get_context.return_value.Queue.assert_called_with(2)
+        mock_get_context.return_value.Process.assert_called_with(
+            target=_execute_pytest_subprocess,
+            args=[["--option", "--ignore=batata"], mock_queue],
+        )
+        assert mock_queue.get.call_count == 2
+        assert result == output
         mock_sys_path.append.assert_not_called()
         mock_getcwd.assert_called()
         assert result == output
 
-    @patch("codecov_cli.runners.python_standard_runner.StringIO")
-    @patch("codecov_cli.runners.python_standard_runner.pytest")
-    def test_collect_tests(self, mock_pytest, mock_stringio):
+    def test_collect_tests(self, mocker):
         collected_test_list = [
             "tests/services/upload/test_upload_service.py::test_do_upload_logic_happy_path_legacy_uploader"
             "tests/services/upload/test_upload_service.py::test_do_upload_logic_happy_path"
             "tests/services/upload/test_upload_service.py::test_do_upload_logic_dry_run"
             "tests/services/upload/test_upload_service.py::test_do_upload_logic_verbose"
         ]
-        mock_getvalue = MagicMock(
-            return_value="\n".join(collected_test_list + [self.output_noise])
+        mock_execute = mocker.patch.object(
+            PythonStandardRunner,
+            "_execute_pytest",
+            return_value="\n".join(collected_test_list),
         )
-        mock_stringio.return_value.__enter__.return_value.getvalue = mock_getvalue
-        mock_pytest.main.return_value = ExitCode.OK
 
         collected_tests_from_runner = self.runner.collect_tests()
-        mock_pytest.main.assert_called_with(["-q", "--collect-only"])
-        mock_stringio.assert_called()
-        mock_getvalue.assert_called()
+        mock_execute.assert_called_with(["-q", "--collect-only"])
         assert collected_tests_from_runner == collected_test_list
 
-    @patch("codecov_cli.runners.python_standard_runner.StringIO")
-    @patch("codecov_cli.runners.python_standard_runner.pytest")
-    def test_collect_tests_with_options(self, mock_pytest, mock_stringio):
+    def test_collect_tests_with_options(self, mocker):
         collected_test_list = [
             "tests/services/upload/test_upload_collector.py::test_fix_go_files"
             "tests/services/upload/test_upload_collector.py::test_fix_php_files"
         ]
-        mock_getvalue = MagicMock(
-            return_value="\n".join(collected_test_list + [self.output_noise])
+        mock_execute = mocker.patch.object(
+            PythonStandardRunner,
+            "_execute_pytest",
+            return_value="\n".join(collected_test_list),
         )
-        mock_stringio.return_value.__enter__.return_value.getvalue = mock_getvalue
-        mock_pytest.main = MagicMock(return_value=ExitCode.OK)
 
         config_params = PythonStandardRunnerConfigParams(
             collect_tests_options=["--option=value", "-option"],
@@ -133,28 +152,22 @@ class TestPythonStandardRunner(object):
         runner_with_params = PythonStandardRunner(config_params)
 
         collected_tests_from_runner = runner_with_params.collect_tests()
-        mock_pytest.main.assert_called_with(
+        mock_execute.assert_called_with(
             ["-q", "--collect-only", "--option=value", "-option"]
         )
-        mock_stringio.assert_called()
-        mock_getvalue.assert_called()
         assert collected_tests_from_runner == collected_test_list
 
-    @patch("codecov_cli.runners.python_standard_runner.StringIO")
-    @patch("codecov_cli.runners.python_standard_runner.pytest")
-    def test_process_label_analysis_result(self, mock_pytest, mock_stringio):
+    def test_process_label_analysis_result(self, mocker):
         label_analysis_result = {
             "present_report_labels": ["test_present"],
             "absent_labels": ["test_absent"],
             "present_diff_labels": ["test_in_diff"],
             "global_level_labels": ["test_global"],
         }
-        mock_pytest.main.return_value = ExitCode.OK
+        mock_execute = mocker.patch.object(PythonStandardRunner, "_execute_pytest")
 
         self.runner.process_labelanalysis_result(label_analysis_result)
-        mock_stringio.assert_called()
-        mock_pytest.main.assert_called()
-        args, kwargs = mock_pytest.main.call_args
+        args, kwargs = mock_execute.call_args
         assert kwargs == {}
         assert isinstance(args[0], list)
         actual_command = args[0]


### PR DESCRIPTION
This change is because when running label-analysis in the sentry test suite it failed, with an error saying that a module already imported cannot be rewritten.

Pytest in its documentation about calling it from python has a note saying:

> Calling pytest.main() will result in importing your tests and any modules that they import.
> Due to the caching mechanism of python’s import system, making subsequent calls to pytest.main() from the same process will not reflect changes to those files between the calls.
> For this reason, making multiple calls to pytest.main() from the same process (in order to re-run tests, for example) is not recommended.

And that is exactly what we were doing, calling `pytest.main` twice: collecting tests, and then executing them.

I thought we'd have to go back to `subprocess.run`, which I really didn't want to do because the move to calling pytest from Python directly was *exactly* so we don't have to use `subprocess.run` (a more dangerous alternative, especially with options from the user).

Luckly the multiprocessing lib in its introduction states:
> The multiprocessing package offers both local and remote concurrency, effectively side-stepping the Global Interpreter Lock by __using subprocesses__ instead of threads.

Et voilá, a viable alternative was born.
These changes move the actual execution of `pytest` to `_execute_pytest_subprocess`, and get the response back using a `multiprocessing.Queue`. The interfaces for `collect_tests` and `process_labelanalysis_result` are left unchanged.

Exciting long term possibilities for this change are paralelization of test execution (`process_labelanalysis_result`) if we simply spaw more processes and divide the list of labels among the different processes. That is left for a future change, though.

The question everyone is asking:
Isn't it easier to just use `subprocess.run` though? Isn't this the same thing as doing that?

Yes, that's easier. But we decided to not use it for a reason - it's potentially dangerous from the customer perspective.

No, this is not the same, because only the `_execute_pytest_subprocess` function is executed in a subprocess, which is very explicitly and DOES NOT accept user options that can easily change what program is running.