### PR TITLE
Don't post-process labels + show pytest output when running tests

### DIFF
--- a/codecov_cli/commands/labelanalysis.py
+++ b/codecov_cli/commands/labelanalysis.py
@@ -60,6 +60,7 @@ def label_analysis(
         f"Selected runner: {runner}",
         extra=dict(extra_log_attributes=dict(config=runner.params)),
     )
+    logger.info("Collecting labels...")
     requested_labels = runner.collect_tests()
     logger.info(f"Collected {len(requested_labels)} tests")
     logger.debug(
@@ -71,6 +72,7 @@ def label_analysis(
         "head_commit": head_commit_sha,
         "requested_labels": requested_labels,
     }
+    logger.info("Requesting set of labels to run...")
     try:
         response = requests.post(
             url, json=payload, headers={"Authorization": token_header}
@@ -108,7 +110,7 @@ def label_analysis(
         raise click.ClickException(click.style("Unable to reach Codecov", fg="red"))
     eid = response.json()["external_id"]
     has_result = False
-    logger.info("Label request sent")
+    logger.info("Label request sent. Waiting for result.")
     time.sleep(2)
     while not has_result:
         resp_data = requests.get(

--- a/codecov_cli/runners/python_standard_runner.py
+++ b/codecov_cli/runners/python_standard_runner.py
@@ -1,9 +1,9 @@
 import logging
 from contextlib import redirect_stdout
-from io import StringIO
+from io import StringIO, TextIOWrapper
 from multiprocessing import Queue, get_context
 from os import getcwd
-from sys import path
+from sys import path, stdout
 from typing import List, TypedDict
 
 import pytest
@@ -37,7 +37,12 @@ def _include_curr_dir(method):
     return call_method
 
 
-def _execute_pytest_subprocess(pytest_args: List[str], queue: Queue):
+def _execute_pytest_subprocess(
+    pytest_args: List[str],
+    queue: Queue,
+    parent_stdout: TextIOWrapper,
+    capture_output: bool = True,
+):
     """Runs pytest from python in a subprocess.
     This is because we call it twice in the label-analysis process,
     so we might have import errors if calling it directly.
@@ -45,11 +50,14 @@ def _execute_pytest_subprocess(pytest_args: List[str], queue: Queue):
 
     Returns the output value and pytest exit code via queue
     """
-    with StringIO() as fd:
-        with redirect_stdout(fd):
-            result = pytest.main(pytest_args)
-        queue.put(fd.getvalue())
-        queue.put(result)
+    subproces_stdout = parent_stdout
+    if capture_output:
+        subproces_stdout = StringIO()
+    with redirect_stdout(subproces_stdout):
+        result = pytest.main(pytest_args)
+    if capture_output:
+        queue.put(subproces_stdout.getvalue())
+    queue.put(result)
 
 
 class PythonStandardRunner(LabelAnalysisRunnerInterface):
@@ -64,16 +72,23 @@ class PythonStandardRunner(LabelAnalysisRunnerInterface):
         self.params = {**default_config, **config_params}
 
     @_include_curr_dir
-    def _execute_pytest(self, pytest_args: List[str], numprocess: int = 1) -> str:
+    def _execute_pytest(
+        self, pytest_args: List[str], capture_output: bool = True, numprocess: int = 1
+    ) -> str:
         """Handles calling pytest from Python in a subprocess.
         Raises Exception if pytest fails
         Returns the complete pytest output
         """
         ctx = get_context("fork")
+        output = None
         queue = ctx.Queue(2)
-        p = ctx.Process(target=_execute_pytest_subprocess, args=[pytest_args, queue])
+        p = ctx.Process(
+            target=_execute_pytest_subprocess,
+            args=[pytest_args, queue, stdout, capture_output],
+        )
         p.start()
-        output = queue.get()  # Output from pytest emitted by subprocess
+        if capture_output:
+            output = queue.get()  # Output from pytest emitted by subprocess
         result = queue.get()  # Pytest exit code emitted by subprocess
         p.join()
 
@@ -97,8 +112,8 @@ class PythonStandardRunner(LabelAnalysisRunnerInterface):
         )
 
         output = self._execute_pytest(options_to_use)
-        lines = output.split()
-        test_names = list(line for line in lines if "::" in line)
+        lines = output.split(sep="\n")
+        test_names = list(line for line in lines if ("::" in line and "test" in line))
         return test_names
 
     def process_labelanalysis_result(self, result: LabelAnalysisRequestResult):
@@ -114,12 +129,12 @@ class PythonStandardRunner(LabelAnalysisRunnerInterface):
                 )
             ),
         )
-        all_labels = (
+        all_labels = set(
             result["absent_labels"]
             + result["present_diff_labels"]
             + result["global_level_labels"]
         )
-        skipped_tests = set(result["present_report_labels"]) - set(all_labels)
+        skipped_tests = set(result["present_report_labels"]) - all_labels
         if skipped_tests:
             logger.info(
                 "Some tests are being skipped",
@@ -127,15 +142,15 @@ class PythonStandardRunner(LabelAnalysisRunnerInterface):
                     extra_log_attributes=dict(skipped_tests=sorted(skipped_tests))
                 ),
             )
-        all_labels = set(all_labels)
-        all_labels = [x.rsplit("[", 1)[0] if "[" in x else x for x in all_labels]
 
-        command_array = default_options + all_labels
+        command_array = default_options + [
+            label.split("[")[0] if "[" in label else label for label in all_labels
+        ]
         logger.info("Running tests")
         logger.debug(
             "Pytest command",
             extra=dict(extra_log_attributes=dict(command_array=command_array)),
         )
-        output = self._execute_pytest(command_array)
+        output = self._execute_pytest(command_array, capture_output=False)
         logger.info("Finished running tests successfully")
         logger.debug(output)


### PR DESCRIPTION
These changes are very much getting-ATS-into-sentry oriented. It is 3 little things that are bundled up together here:

1. I was having issues with the labels collected where the split of output lines was strange. This was apparetly solved by explicitly using `sep="\n"` in the split function
2. I was having issues because we were post-processing labels removing `[marks]` from them. These marks come from `pytest.mark.parametrize`, but apparently they can be incredibly complex, and include multiple bracket pairs. This was breaking the test runs because we'd give wrong labels. I didn't want to remove it completely because I don't know if it would cause processing errors or coverage differences afterwards. I don't _think_ so, but decided to just play safe and remove everything within the brackets, which also seems to work.
3. When running tests we couldn't see the progress of pytest in the subprocess. This was because we are capturing the output. We don't want this when tests are running, so I'm just not capturing it anymore. Now we see the progress when running tests. And also some small improvements to label-analysis not-verbose output.