### PR TITLE
Update release flow so it works on manual releases

### DIFF
--- a/.github/workflows/release_flow.yml
+++ b/.github/workflows/release_flow.yml
@@ -4,12 +4,11 @@
 name: Build-and-Release
 
 on:
-  push:
-    tags:
-      - 'v*' # Runs only for tags that start with v (new versions)
+  release:
+    types: created
 
 jobs:
-  build_and_publish:
+  build_and_publish_to_pipy:
     runs-on: ubuntu-latest
     permissions:
       id-token: write # This is required for requesting the JWT
@@ -36,37 +35,8 @@ jobs:
     - name: Publish package to PyPi
       uses: pypa/gh-action-pypi-publish@release/v1
 
-  changelog:
-    runs-on: ubuntu-latest
-    needs: build_and_publish
-    steps:
-      - name: "Generate release changelog"
-        uses: heinrichreimer/github-changelog-generator-action@v2.3
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }} 
-
-  createrelease:
-    name: Create Release
-    runs-on: ubuntu-latest
-    needs: changelog
-    outputs:
-      upload_url: ${{ steps.create_release.outputs.upload_url }}
-    steps:
-    - name: Create Release For Tag
-      id: create_release
-      uses: actions/create-release@v1
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-        tag_name: ${{ github.ref_name }}
-        release_name: Release ${{ github.ref_name }}
-        body: ${{ needs.changelog.outputs.changelog }}
-        draft: ${{ contains(github.ref_name, 'test') }}
-        prerelease: ${{ contains(github.ref_name, 'beta') }}
-
   buildassets:
     name: Build packages
-    needs: createrelease
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: true
@@ -113,32 +83,17 @@ jobs:
       run: ${{matrix.CMD_BUILD}}
     - name: Upload Release Asset
       id: upload-release-asset
-      uses: actions/upload-release-asset@v1
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      uses: svenstaro/upload-release-action@v2
       with:
-        upload_url: ${{ needs.createrelease.outputs.upload_url }}
-        asset_path: ./dist/${{ matrix.OUT_FILE_NAME }}
+        repo_token: ${{ secrets.GITHUB_TOKEN }}
+        file: ./dist/${{ matrix.OUT_FILE_NAME }}
         asset_name: ${{ matrix.OUT_FILE_NAME }}
-        asset_content_type: ${{ matrix.ASSET_MIME }}
-
-  purge_release_if_failed:
-    name: Delete release if build failed
-    needs: buildassets
-    runs-on: ubuntu-latest
-    if: ${{ failure() || cancelled() }}
-    steps:
-    - uses: dev-drprasad/delete-tag-and-release@v0.2.0
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-        delete_release: true
-        tag_name: ${{ github.ref_name }}
-
+        tag: ${{ github.ref }}
+        overwrite: true
   
   publish_release:
     name: Publish release
-    needs: buildassets
+    needs: [buildassets, build_and_publish_to_pipy]
     runs-on: ubuntu-latest
     permissions:
       contents: 'read'


### PR DESCRIPTION
I tested this by creating releases for this branch and then deleting them (because at some point deleting the release also triggered the workflow haha)

So it seems that when we make a new release it runs the workflow as expected. If you delete the release it doesn't run the workflow as expected.

It will push to pypi and build the assets and push them to github.
If BOTH those work nicely then we publish the release in cli.codecov.io