### PR TITLE
Improve logging

### DIFF
--- a/codecov_cli/helpers/request.py
+++ b/codecov_cli/helpers/request.py
@@ -59,7 +59,7 @@ def request_result(resp):
 def log_warnings_and_errors_if_any(
     sending_result: RequestResult, process_desc: str, fail_on_error: bool = False
 ):
-    logger.debug(
+    logger.info(
         f"Process {process_desc} complete.",
         extra=dict(extra_log_attributes=dict(result=sending_result)),
     )

--- a/codecov_cli/helpers/request.py
+++ b/codecov_cli/helpers/request.py
@@ -60,7 +60,10 @@ def log_warnings_and_errors_if_any(
     sending_result: RequestResult, process_desc: str, fail_on_error: bool = False
 ):
     logger.info(
-        f"Process {process_desc} complete.",
+        f"Process {process_desc} complete",
+    )
+    logger.debug(
+        f"{process_desc} result",
         extra=dict(extra_log_attributes=dict(result=sending_result)),
     )
     if sending_result.warnings:

--- a/codecov_cli/services/upload/upload_collector.py
+++ b/codecov_cli/services/upload/upload_collector.py
@@ -131,9 +131,9 @@ class UploadCollector(object):
         logger.debug("Collecting relevant files")
         network = self.network_finder.find_files()
         coverage_files = self.coverage_file_finder.find_coverage_files()
-        logger.debug(f"Found {len(coverage_files)} coverage files to upload")
+        logger.info(f"Found {len(coverage_files)} coverage files to upload")
         for file in coverage_files:
-            logger.debug(f"> {file}")
+            logger.info(f"> {file}")
         return UploadCollectionResult(
             network=network,
             coverage_files=coverage_files,

--- a/tests/services/commit/test_commit_service.py
+++ b/tests/services/commit/test_commit_service.py
@@ -31,10 +31,7 @@ def test_commit_command_with_warnings(mocker):
 
     out_bytes = parse_outstreams_into_log_lines(outstreams[0].getvalue())
     assert out_bytes == [
-        (
-            "info",
-            "Process Commit creating complete. --- {\"result\": \"RequestResult(error=None, warnings=[RequestResultWarning(message='somewarningmessage')], status_code=201, text='')\"}",
-        ),
+        ("info", "Process Commit creating complete"),
         ("info", "Commit creating process had 1 warning"),
         ("warning", "Warning 1: somewarningmessage"),
     ]
@@ -80,7 +77,7 @@ def test_commit_command_with_error(mocker):
     assert out_bytes == [
         (
             "info",
-            "Process Commit creating complete. --- {\"result\": \"RequestResult(error=RequestError(code='HTTP Error 403', params={}, description='Permission denied'), warnings=[], status_code=403, text='Permission denied')\"}",
+            "Process Commit creating complete",
         ),
         ("error", "Commit creating failed: Permission denied"),
     ]

--- a/tests/services/commit/test_commit_service.py
+++ b/tests/services/commit/test_commit_service.py
@@ -31,6 +31,10 @@ def test_commit_command_with_warnings(mocker):
 
     out_bytes = parse_outstreams_into_log_lines(outstreams[0].getvalue())
     assert out_bytes == [
+        (
+            "info",
+            "Process Commit creating complete. --- {\"result\": \"RequestResult(error=None, warnings=[RequestResultWarning(message='somewarningmessage')], status_code=201, text='')\"}",
+        ),
         ("info", "Commit creating process had 1 warning"),
         ("warning", "Warning 1: somewarningmessage"),
     ]
@@ -73,7 +77,13 @@ def test_commit_command_with_error(mocker):
         )
 
     out_bytes = parse_outstreams_into_log_lines(outstreams[0].getvalue())
-    assert out_bytes == [("error", "Commit creating failed: Permission denied")]
+    assert out_bytes == [
+        (
+            "info",
+            "Process Commit creating complete. --- {\"result\": \"RequestResult(error=RequestError(code='HTTP Error 403', params={}, description='Permission denied'), warnings=[], status_code=403, text='Permission denied')\"}",
+        ),
+        ("error", "Commit creating failed: Permission denied"),
+    ]
     assert res == mock_send_commit_data.return_value
     mock_send_commit_data.assert_called_with(
         commit_sha="commit_sha",

--- a/tests/services/report/test_report_results.py
+++ b/tests/services/report/test_report_results.py
@@ -34,6 +34,10 @@ def test_report_results_command_with_warnings(mocker):
 
     out_bytes = parse_outstreams_into_log_lines(outstreams[0].getvalue())
     assert out_bytes == [
+        (
+            "info",
+            "Process Report results creating complete. --- {\"result\": \"RequestResult(error=None, warnings=[RequestResultWarning(message='somewarningmessage')], status_code=201, text='')\"}",
+        ),
         ("info", "Report results creating process had 1 warning"),
         ("warning", "Warning 1: somewarningmessage"),
     ]
@@ -73,7 +77,13 @@ def test_report_results_command_with_error(mocker):
         )
 
     out_bytes = parse_outstreams_into_log_lines(outstreams[0].getvalue())
-    assert out_bytes == [("error", "Report results creating failed: Permission denied")]
+    assert out_bytes == [
+        (
+            "info",
+            "Process Report results creating complete. --- {\"result\": \"RequestResult(error=RequestError(code='HTTP Error 403', params={}, description='Permission denied'), warnings=[], status_code=403, text='Permission denied')\"}",
+        ),
+        ("error", "Report results creating failed: Permission denied"),
+    ]
     assert res == mock_send_reports_result_request.return_value
     mock_send_reports_result_request.assert_called_with(
         commit_sha="commit_sha",

--- a/tests/services/report/test_report_results.py
+++ b/tests/services/report/test_report_results.py
@@ -34,10 +34,7 @@ def test_report_results_command_with_warnings(mocker):
 
     out_bytes = parse_outstreams_into_log_lines(outstreams[0].getvalue())
     assert out_bytes == [
-        (
-            "info",
-            "Process Report results creating complete. --- {\"result\": \"RequestResult(error=None, warnings=[RequestResultWarning(message='somewarningmessage')], status_code=201, text='')\"}",
-        ),
+        ("info", "Process Report results creating complete"),
         ("info", "Report results creating process had 1 warning"),
         ("warning", "Warning 1: somewarningmessage"),
     ]
@@ -78,10 +75,7 @@ def test_report_results_command_with_error(mocker):
 
     out_bytes = parse_outstreams_into_log_lines(outstreams[0].getvalue())
     assert out_bytes == [
-        (
-            "info",
-            "Process Report results creating complete. --- {\"result\": \"RequestResult(error=RequestError(code='HTTP Error 403', params={}, description='Permission denied'), warnings=[], status_code=403, text='Permission denied')\"}",
-        ),
+        ("info", "Process Report results creating complete"),
         ("error", "Report results creating failed: Permission denied"),
     ]
     assert res == mock_send_reports_result_request.return_value

--- a/tests/services/report/test_report_service.py
+++ b/tests/services/report/test_report_service.py
@@ -58,10 +58,7 @@ def test_create_report_command_with_warnings(mocker):
 
     out_bytes = parse_outstreams_into_log_lines(outstreams[0].getvalue())
     assert out_bytes == [
-        (
-            "info",
-            "Process Report creating complete. --- {\"result\": \"RequestResult(error=None, warnings=[RequestResultWarning(message='somewarningmessage')], status_code=200, text='')\"}",
-        ),
+        ("info", "Process Report creating complete"),
         ("info", "Report creating process had 1 warning"),
         ("warning", "Warning 1: somewarningmessage"),
     ]
@@ -106,10 +103,7 @@ def test_create_report_command_with_error(mocker):
 
     out_bytes = parse_outstreams_into_log_lines(outstreams[0].getvalue())
     assert out_bytes == [
-        (
-            "info",
-            "Process Report creating complete. --- {\"result\": \"RequestResult(error=RequestError(code='HTTP Error 403', params={}, description='Permission denied'), warnings=[], status_code=403, text='')\"}",
-        ),
+        ("info", "Process Report creating complete"),
         ("error", "Report creating failed: Permission denied"),
     ]
     assert res == RequestResult(

--- a/tests/services/report/test_report_service.py
+++ b/tests/services/report/test_report_service.py
@@ -58,6 +58,10 @@ def test_create_report_command_with_warnings(mocker):
 
     out_bytes = parse_outstreams_into_log_lines(outstreams[0].getvalue())
     assert out_bytes == [
+        (
+            "info",
+            "Process Report creating complete. --- {\"result\": \"RequestResult(error=None, warnings=[RequestResultWarning(message='somewarningmessage')], status_code=200, text='')\"}",
+        ),
         ("info", "Report creating process had 1 warning"),
         ("warning", "Warning 1: somewarningmessage"),
     ]
@@ -101,7 +105,13 @@ def test_create_report_command_with_error(mocker):
         )
 
     out_bytes = parse_outstreams_into_log_lines(outstreams[0].getvalue())
-    assert out_bytes == [("error", "Report creating failed: Permission denied")]
+    assert out_bytes == [
+        (
+            "info",
+            "Process Report creating complete. --- {\"result\": \"RequestResult(error=RequestError(code='HTTP Error 403', params={}, description='Permission denied'), warnings=[], status_code=403, text='')\"}",
+        ),
+        ("error", "Report creating failed: Permission denied"),
+    ]
     assert res == RequestResult(
         error=RequestError(
             code="HTTP Error 403",

--- a/tests/services/upload/test_upload_service.py
+++ b/tests/services/upload/test_upload_service.py
@@ -69,10 +69,7 @@ def test_do_upload_logic_happy_path_legacy_uploader(mocker):
         )
     out_bytes = parse_outstreams_into_log_lines(outstreams[0].getvalue())
     assert out_bytes == [
-        (
-            "info",
-            'Process Upload complete. --- {"result": "UploadSendingResult(error=None, warnings=[UploadSendingResultWarning(message=\'somewarningmessage\')])"}',
-        ),
+        ("info", "Process Upload complete"),
         ("info", "Upload process had 1 warning"),
         ("warning", "Warning 1: somewarningmessage"),
     ]
@@ -155,10 +152,7 @@ def test_do_upload_logic_happy_path(mocker):
         )
     out_bytes = parse_outstreams_into_log_lines(outstreams[0].getvalue())
     assert out_bytes == [
-        (
-            "info",
-            'Process Upload complete. --- {"result": "UploadSendingResult(error=None, warnings=[UploadSendingResultWarning(message=\'somewarningmessage\')])"}',
-        ),
+        ("info", "Process Upload complete"),
         ("info", "Upload process had 1 warning"),
         ("warning", "Warning 1: somewarningmessage"),
     ]
@@ -246,10 +240,7 @@ def test_do_upload_logic_dry_run(mocker):
     )
     assert out_bytes == [
         ("info", "dry-run option activated. NOT sending data to Codecov."),
-        (
-            "info",
-            'Process Upload complete. --- {"result": "RequestResult(error=None, warnings=None, status_code=200, text=\'Data NOT sent to Codecov because of dry-run option\')"}',
-        ),
+        ("info", "Process Upload complete"),
     ]
     assert res == RequestResult(
         error=None,
@@ -306,9 +297,10 @@ def test_do_upload_logic_verbose(mocker, use_verbose_option):
             "Selected uploader to use: <class 'codecov_cli.services.upload.legacy_upload_sender.LegacyUploadSender'>",
         ),
         ("info", "dry-run option activated. NOT sending data to Codecov."),
+        ("info", "Process Upload complete"),
         (
-            "info",
-            'Process Upload complete. --- {"result": "RequestResult(error=None, warnings=None, status_code=200, text=\'Data NOT sent to Codecov because of dry-run option\')"}',
+            "debug",
+            'Upload result --- {"result": "RequestResult(error=None, warnings=None, status_code=200, text=\'Data NOT sent to Codecov because of dry-run option\')"}',
         ),
     ]
     assert res == RequestResult(

--- a/tests/services/upload/test_upload_service.py
+++ b/tests/services/upload/test_upload_service.py
@@ -69,6 +69,10 @@ def test_do_upload_logic_happy_path_legacy_uploader(mocker):
         )
     out_bytes = parse_outstreams_into_log_lines(outstreams[0].getvalue())
     assert out_bytes == [
+        (
+            "info",
+            'Process Upload complete. --- {"result": "UploadSendingResult(error=None, warnings=[UploadSendingResultWarning(message=\'somewarningmessage\')])"}',
+        ),
         ("info", "Upload process had 1 warning"),
         ("warning", "Warning 1: somewarningmessage"),
     ]
@@ -151,6 +155,10 @@ def test_do_upload_logic_happy_path(mocker):
         )
     out_bytes = parse_outstreams_into_log_lines(outstreams[0].getvalue())
     assert out_bytes == [
+        (
+            "info",
+            'Process Upload complete. --- {"result": "UploadSendingResult(error=None, warnings=[UploadSendingResultWarning(message=\'somewarningmessage\')])"}',
+        ),
         ("info", "Upload process had 1 warning"),
         ("warning", "Warning 1: somewarningmessage"),
     ]
@@ -237,7 +245,11 @@ def test_do_upload_logic_dry_run(mocker):
         cli_config, ["first_plugin", "another", "forth"]
     )
     assert out_bytes == [
-        ("info", "dry-run option activated. NOT sending data to Codecov.")
+        ("info", "dry-run option activated. NOT sending data to Codecov."),
+        (
+            "info",
+            'Process Upload complete. --- {"result": "RequestResult(error=None, warnings=None, status_code=200, text=\'Data NOT sent to Codecov because of dry-run option\')"}',
+        ),
     ]
     assert res == RequestResult(
         error=None,
@@ -295,7 +307,7 @@ def test_do_upload_logic_verbose(mocker, use_verbose_option):
         ),
         ("info", "dry-run option activated. NOT sending data to Codecov."),
         (
-            "debug",
+            "info",
             'Process Upload complete. --- {"result": "RequestResult(error=None, warnings=None, status_code=200, text=\'Data NOT sent to Codecov because of dry-run option\')"}',
         ),
     ]


### PR DESCRIPTION
Trying to strike the right balance between verbose and non-verbose mode in the CLI.

Particularly for the upload command it's been not satisfactory. The list of files being uploaded as coverage is now listed in non-verbose mode.

Plus there's a positive feedback now that the process (command) finished - for ALL commands. So you know that at least the CLI did its thing, even though there might still be errors.

And again for the upload command, separate better the response from codecov-api and the response from the PUT request afterwards.
To help debugging and all that.