### PR TITLE
Always feed pytest at least 1 label

### DIFF
--- a/codecov_cli/runners/python_standard_runner.py
+++ b/codecov_cli/runners/python_standard_runner.py
@@ -1,4 +1,5 @@
 import logging
+import random
 from contextlib import redirect_stdout
 from io import StringIO, TextIOWrapper
 from multiprocessing import Queue, get_context
@@ -143,6 +144,12 @@ class PythonStandardRunner(LabelAnalysisRunnerInterface):
                 ),
             )
 
+        if len(all_labels) == 0:
+            all_labels = [random.choice(result["present_report_labels"])]
+            logger.info(
+                "All tests are being skipped. Selected random label to run",
+                extra=dict(extra_log_attributes=dict(selected_label=all_labels[0])),
+            )
         command_array = default_options + [
             label.split("[")[0] if "[" in label else label for label in all_labels
         ]

--- a/tests/runners/test_python_standard_runner.py
+++ b/tests/runners/test_python_standard_runner.py
@@ -194,3 +194,25 @@ class TestPythonStandardRunner(object):
             "test_global",
             "test_in_diff",
         ]
+
+    def test_process_label_analysis_skip_all_tests(self, mocker):
+        label_analysis_result = {
+            "present_report_labels": ["test_present"],
+            "absent_labels": [],
+            "present_diff_labels": [],
+            "global_level_labels": [],
+        }
+        mock_execute = mocker.patch.object(PythonStandardRunner, "_execute_pytest")
+
+        self.runner.process_labelanalysis_result(label_analysis_result)
+        args, kwargs = mock_execute.call_args
+        assert kwargs == {"capture_output": False}
+        assert isinstance(args[0], list)
+        actual_command = args[0]
+        assert actual_command[:2] == [
+            "--cov=./",
+            "--cov-context=test",
+        ]
+        assert sorted(actual_command[2:]) == [
+            "test_present",
+        ]


### PR DESCRIPTION
We currently have this bug when all tests can be skipped,
then `all_labels` is empty, and we give pytest no labels to execute.
This means it will then collect and execute ALL tests in the suite.

The ideal solution is to bail out and do an empty upload.
However, while empty upload is not available, we are going to select 1 test as random,
and run that single random test label.