### PR TITLE
Removed TypedDict

### DIFF
--- a/codecov_cli/commands/labelanalysis.py
+++ b/codecov_cli/commands/labelanalysis.py
@@ -6,6 +6,7 @@ import requests
 
 from codecov_cli.fallbacks import CodecovOption, FallbackFieldEnum
 from codecov_cli.runners import get_runner
+from codecov_cli.runners.types import LabelAnalysisRequestResult
 
 logger = logging.getLogger("codecovcli")
 
@@ -86,12 +87,14 @@ def label_analysis(
                 logger.info(
                     "Could not get set of tests to run. Falling back to running all collected tests."
                 )
-                fake_response = {
-                    "present_report_labels": [],
-                    "absent_labels": requested_labels,
-                    "present_diff_labels": [],
-                    "global_level_labels": [],
-                }
+                fake_response = LabelAnalysisRequestResult(
+                    {
+                        "present_report_labels": [],
+                        "absent_labels": requested_labels,
+                        "present_diff_labels": [],
+                        "global_level_labels": [],
+                    }
+                )
                 return runner.process_labelanalysis_result(fake_response)
             raise click.ClickException("Sorry. Codecov is having problems")
         if response.status_code >= 400:
@@ -119,7 +122,9 @@ def label_analysis(
         )
         resp_json = resp_data.json()
         if resp_json["state"] == "finished":
-            runner.process_labelanalysis_result(resp_data.json()["result"])
+            runner.process_labelanalysis_result(
+                LabelAnalysisRequestResult(resp_data.json()["result"])
+            )
             return
         if resp_json["state"] == "error":
             logger.error(
@@ -128,12 +133,14 @@ def label_analysis(
             )
             if requested_labels:
                 logger.info("Using requested labels as tests to run")
-                fake_response = {
-                    "present_report_labels": [],
-                    "absent_labels": requested_labels,
-                    "present_diff_labels": [],
-                    "global_level_labels": [],
-                }
+                fake_response = LabelAnalysisRequestResult(
+                    {
+                        "present_report_labels": [],
+                        "absent_labels": requested_labels,
+                        "present_diff_labels": [],
+                        "global_level_labels": [],
+                    }
+                )
                 return runner.process_labelanalysis_result(fake_response)
             return
         logger.info("Waiting more time for result")

--- a/codecov_cli/runners/dan_runner.py
+++ b/codecov_cli/runners/dan_runner.py
@@ -1,5 +1,5 @@
 import subprocess
-from typing import List, TypedDict, Union
+from typing import List, Optional, Union
 
 from codecov_cli.runners.types import (
     LabelAnalysisRequestResult,
@@ -7,20 +7,25 @@ from codecov_cli.runners.types import (
 )
 
 
-class DoAnythingNowConfigParams(TypedDict):
-    collect_tests_command: Union[List[str], str]
-    process_labelanalysis_result_command: Union[List[str], str]
+class DoAnythingNowConfigParams(dict):
+    @property
+    def collect_tests_command(self) -> Union[List[str], str]:
+        return self.get("collect_tests_command", None)
+
+    @property
+    def process_labelanalysis_result_command(self) -> Union[List[str], str]:
+        return self.get("process_labelanalysis_result_command", None)
 
 
 class DoAnythingNowRunner(LabelAnalysisRunnerInterface):
-    def __init__(self, config_params: DoAnythingNowConfigParams = None) -> None:
+    def __init__(self, config_params: Optional[dict] = None) -> None:
         super().__init__()
         if config_params is None:
-            config_params = DoAnythingNowConfigParams()
-        self.params = config_params
+            config_params = {}
+        self.params = DoAnythingNowConfigParams(config_params)
 
     def collect_tests(self) -> List[str]:
-        command = self.params.get("collect_tests_command", None)
+        command = self.params.collect_tests_command
         if command is None:
             raise Exception(
                 "DAN runner missing 'collect_tests_command' configuration value"
@@ -28,7 +33,7 @@ class DoAnythingNowRunner(LabelAnalysisRunnerInterface):
         return subprocess.run(command, check=True, capture_output=True).stdout.decode()
 
     def process_labelanalysis_result(self, result: LabelAnalysisRequestResult):
-        command = self.params.get("process_labelanalysis_result_command", None)
+        command = self.params.process_labelanalysis_result_command
         if command is None:
             raise Exception(
                 "DAN runner missing 'process_labelanalysis_result_command' configuration value"

--- a/codecov_cli/runners/types.py
+++ b/codecov_cli/runners/types.py
@@ -1,11 +1,25 @@
-from typing import List, TypedDict
+from typing import List
 
 
-class LabelAnalysisRequestResult(TypedDict):
-    present_report_labels: List[str]
-    absent_labels: List[str]
-    present_diff_labels: List[str]
-    global_level_labels: List[str]
+# This is supposed to be a TypedDict,
+# But that is Python >= 3.7 only
+# So we are not using those
+class LabelAnalysisRequestResult(dict):
+    @property
+    def present_report_labels(self) -> List[str]:
+        return self.get("present_report_labels", [])
+
+    @property
+    def absent_labels(self) -> List[str]:
+        return self.get("absent_labels", [])
+
+    @property
+    def present_diff_labels(self) -> List[str]:
+        return self.get("present_diff_labels", [])
+
+    @property
+    def global_level_labels(self) -> List[str]:
+        return self.get("global_level_labels", [])
 
 
 class LabelAnalysisRunnerInterface(object):

--- a/tests/runners/test_dan_runner.py
+++ b/tests/runners/test_dan_runner.py
@@ -3,10 +3,9 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from codecov_cli.runners.dan_runner import DoAnythingNowRunner
-from codecov_cli.runners.python_standard_runner import PythonStandardRunner
 
 
-class TestPythonStandardRunner(object):
+class TestDoAnythingNowRunner(object):
     @patch("codecov_cli.runners.dan_runner.subprocess.run")
     def test_collect_tests(self, mock_run):
         test_list = ["test_1", "test_2", "test_3"]

--- a/tests/runners/test_python_standard_runner.py
+++ b/tests/runners/test_python_standard_runner.py
@@ -44,11 +44,12 @@ class TestPythonStandardRunner(object):
     runner = PythonStandardRunner()
 
     def test_init_with_params(self):
-        assert self.runner.params == PythonStandardRunnerConfigParams(
-            collect_tests_options=[], include_curr_dir=True
-        )
-        config_params = PythonStandardRunnerConfigParams(
-            collect_tests_options=["--option=value", "-option"], include_curr_dir=True
+        assert self.runner.params.collect_tests_options == []
+        assert self.runner.params.include_curr_dir == True
+
+        config_params = dict(
+            collect_tests_options=["--option=value", "-option"],
+            include_curr_dir=False,
         )
         runner_with_params = PythonStandardRunner(config_params)
         assert runner_with_params.params == config_params
@@ -118,7 +119,7 @@ class TestPythonStandardRunner(object):
         mock_get_context.return_value.Queue.return_value = mock_queue
         mock_get_context.return_value.Process.return_value = mock_process
 
-        config_params = PythonStandardRunnerConfigParams(include_curr_dir=False)
+        config_params = dict(include_curr_dir=False)
         runner = PythonStandardRunner(config_params=config_params)
         result = runner._execute_pytest(["--option", "--ignore=batata"])
         mock_get_context.return_value.Queue.assert_called_with(2)
@@ -160,9 +161,7 @@ class TestPythonStandardRunner(object):
             return_value="\n".join(collected_test_list),
         )
 
-        config_params = PythonStandardRunnerConfigParams(
-            collect_tests_options=["--option=value", "-option"],
-        )
+        config_params = dict(collect_tests_options=["--option=value", "-option"])
         runner_with_params = PythonStandardRunner(config_params)
 
         collected_tests_from_runner = runner_with_params.collect_tests()

--- a/tests/runners/test_runners.py
+++ b/tests/runners/test_runners.py
@@ -17,7 +17,11 @@ class TestRunners(object):
         )
         runner_instance = get_runner({"runners": {"python": config_params}}, "python")
         assert isinstance(runner_instance, PythonStandardRunner)
-        assert runner_instance.params == {**config_params, "include_curr_dir": True}
+        assert (
+            runner_instance.params.collect_tests_options
+            == config_params["collect_tests_options"]
+        )
+        assert runner_instance.params.include_curr_dir == True
 
     def test_get_dan_runner_with_params(self):
         config = {

--- a/tests/runners/test_types.py
+++ b/tests/runners/test_types.py
@@ -1,0 +1,18 @@
+from codecov_cli.runners.types import LabelAnalysisRequestResult
+
+
+class TestLabelAnalysisRequestResult(object):
+    def test_creation(self):
+        result = LabelAnalysisRequestResult(
+            {
+                "present_report_labels": ["test_present"],
+                "absent_labels": ["test_absent"],
+                "present_diff_labels": ["test_diff"],
+                "global_level_labels": ["test_global"],
+            }
+        )
+        assert result.present_report_labels == ["test_present"]
+        assert result.absent_labels == ["test_absent"]
+        assert result.present_diff_labels == ["test_diff"]
+        assert result.global_level_labels == ["test_global"]
+        assert result["present_report_labels"] == ["test_present"]


### PR DESCRIPTION
TypedDict became part of typing in Python 3.8
We are interested in supporting the CLI in earlier versions of Python 3, so removing it.
It's a bit hacky, but works.
I was careful to make sure we are casting to the new types so we can use the properties if we choose to do so.