### PR TITLE
fix failing tests

### DIFF
--- a/codecov_cli/services/empty_upload/__init__.py
+++ b/codecov_cli/services/empty_upload/__init__.py
@@ -15,7 +15,5 @@ def empty_upload_logic(commit_sha, slug, token, git_service):
     headers = get_token_header_or_fail(token)
     url = f"https://api.codecov.io/upload/{git_service}/{encoded_slug}/commits/{commit_sha}/empty-upload"
     sending_result = send_post_request(url=url, headers=headers)
-    if sending_result.status_code < 300 and sending_result.text:
-        logger.info(sending_result.text)
     log_warnings_and_errors_if_any(sending_result, "Empty Upload")
     return sending_result

--- a/tests/services/empty_upload/test_empty_upload.py
+++ b/tests/services/empty_upload/test_empty_upload.py
@@ -27,6 +27,7 @@ def test_empty_upload_with_warnings(mocker):
         )
     out_bytes = parse_outstreams_into_log_lines(outstreams[0].getvalue())
     assert out_bytes == [
+        ("info", "Process Empty Upload complete"),
         ("info", "Empty Upload process had 1 warning"),
         ("warning", "Warning 1: somewarningmessage"),
     ]
@@ -59,7 +60,10 @@ def test_empty_upload_with_error(mocker):
 
     print(outstreams)
     out_bytes = parse_outstreams_into_log_lines(outstreams[0].getvalue())
-    assert out_bytes == [("error", "Empty Upload failed: Permission denied")]
+    assert out_bytes == [
+        ("info", "Process Empty Upload complete"),
+        ("error", "Empty Upload failed: Permission denied"),
+    ]
     assert res == mock_send_commit_data.return_value
     mock_send_commit_data.assert_called_once()
 


### PR DESCRIPTION
After merging the empty upload PR into master, the logging tests failed due to a change made earlier 
This PR fixes the failing tests and remove the logging of the result as we already do that along with the errors and warnings 