### PR TITLE
Add config options to pycoverage plugin

### DIFF
--- a/codecov_cli/plugins/__init__.py
+++ b/codecov_cli/plugins/__init__.py
@@ -50,7 +50,8 @@ def _get_plugin(cli_config, plugin_name):
     if plugin_name == "gcov":
         return GcovPlugin()
     if plugin_name == "pycoverage":
-        return Pycoverage()
+        config = cli_config.get("plugins", {}).get("pycoverage", {})
+        return Pycoverage(config)
     if plugin_name == "xcode":
         return XcodePlugin()
     if cli_config and plugin_name in cli_config.get("plugins", {}):

--- a/codecov_cli/plugins/pycoverage.py
+++ b/codecov_cli/plugins/pycoverage.py
@@ -13,20 +13,76 @@ coverage_files_regex = globs_to_regex([".coverage", ".coverage.*"])
 logger = logging.getLogger("codecovcli")
 
 
+class PycoverageConfig(dict):
+    @property
+    def project_root(self) -> typing.Optional[pathlib.Path]:
+        """
+        The project root to search for coverage files.
+        project_root: pathlib.Path [default os.getcwd()]
+        """
+        return self.get("project_root", pathlib.Path(os.getcwd()))
+
+    @property
+    def report_type(self) -> str:
+        """
+        Report type to generate.
+        Overrided if include_contexts == True
+        report_type: str [values xml|json; default xml]
+        """
+        return self.get("report_type", "xml")
+
+    @property
+    def path_to_coverage_file(self) -> str:
+        """
+        The coverage dir with .coverage file
+        If set, will not look search for coverage files
+        """
+        return self.get("path_to_coverage_file", None)
+
+    @property
+    def include_contexts(self) -> bool:
+        """
+        Includes test context in JSON report. Flag.
+        (test contexts are the test labels used in ATS)
+        include_contexts: bool [default True]
+        """
+        return self.get("include_contexts", True)
+
+
 class Pycoverage(object):
-    def __init__(self, project_root: typing.Optional[pathlib.Path] = None):
-        self.project_root = project_root or pathlib.Path(os.getcwd())
+    def __init__(self, config: dict):
+        self.config = PycoverageConfig(config)
 
     def run_preparation(self, collector) -> PreparationPluginReturn:
-        logger.debug("Running coverage.py plugin...")
 
         if shutil.which("coverage") is None:
             logger.warning("coverage.py is not installed or can't be found.")
             return
 
-        path_to_coverage_data = next(
+        path_to_coverage_data = self._get_path_to_coverage()
+        if path_to_coverage_data is None:
+            logger.warning("No coverage data found to transform")
+            return
+        coverage_dir = pathlib.Path(path_to_coverage_data).parent
+        if self.config.report_type == "xml":
+            return self._generate_XML_report(coverage_dir)
+        if self.config.report_type == "json":
+            return self._generate_JSON_report(coverage_dir)
+        return PreparationPluginReturn(
+            success=False, messages=[f"report type {self.config.report_type} unknown"]
+        )
+
+    def _get_path_to_coverage(self) -> pathlib.Path:
+        if self.config.path_to_coverage_file:
+            path = pathlib.Path(self.config.path_to_coverage_file)
+            if path.exists():
+                return pathlib.Path(self.config.path_to_coverage_file)
+            logger.warning(
+                f"Dir {self.config.path_to_coverage_file} doesn't exist or doesn't have .coverage file. Falling back to search"
+            )
+        return next(
             search_files(
-                self.project_root,
+                self.config.project_root,
                 [],
                 filename_include_regex=coverage_files_regex,
                 filename_exclude_regex=None,
@@ -34,20 +90,9 @@ class Pycoverage(object):
             None,
         )
 
-        if path_to_coverage_data is None:
-            logger.warning("No coverage data found to transform")
-            return
-
-        coverage_data_directory = pathlib.Path(path_to_coverage_data).parent
-        self._generate_XML_report(coverage_data_directory)
-
-        return PreparationPluginReturn(success=True, messages=[])
-
-    def _generate_XML_report(self, dir: pathlib.Path):
+    def _generate_XML_report(self, dir: pathlib.Path) -> PreparationPluginReturn:
         """Generates up-to-date XML report in the given directory"""
-
         # the following if conditions avoid creating dummy .coverage file
-
         if next(iglob(str(dir / ".coverage.*")), None) is not None:
             logger.info(f"Running coverage combine -a in {dir}")
             subprocess.run(["coverage", "combine", "-a"], cwd=dir)
@@ -60,3 +105,27 @@ class Pycoverage(object):
 
             output = completed_process.stdout.decode().strip()
             logger.info(output)
+        return PreparationPluginReturn(success=True, messages=[])
+
+    def _generate_JSON_report(self, dir: pathlib.Path):
+        if (dir / ".coverage").exists():
+            logger.info(
+                f"Generating JSON report in {dir}",
+                extra=dict(
+                    extra_log_attributes=dict(
+                        include_contexts=self.config.include_contexts
+                    )
+                ),
+            )
+            command = ["coverage", "json"]
+            if self.config.include_contexts:
+                command.append("--show-contexts")
+            completed_process = subprocess.run(command, cwd=dir, capture_output=True)
+
+            output = completed_process.stdout.decode().strip()
+            logger.info(output)
+            return PreparationPluginReturn(success=True, messages=[])
+        logger.warning(f".coverage file not found at {dir}. Parsing failed")
+        return PreparationPluginReturn(
+            success=False, messages=[f".coverage file not found at {dir}."]
+        )

--- a/tests/plugins/test_instantiation.py
+++ b/tests/plugins/test_instantiation.py
@@ -6,6 +6,7 @@ from codecov_cli.plugins import (
     _load_plugin_from_yaml,
     select_preparation_plugins,
 )
+from codecov_cli.plugins.pycoverage import Pycoverage, PycoverageConfig
 
 
 def test_load_plugin_from_yaml(mocker):
@@ -50,6 +51,19 @@ def test_get_plugin_gcov():
 def test_get_plugin_xcode():
     res = _get_plugin({}, "xcode")
     assert isinstance(res, XcodePlugin)
+
+
+def test_get_plugin_pycoverage():
+    res = _get_plugin({}, "pycoverage")
+    assert isinstance(res, Pycoverage)
+    assert res.config == PycoverageConfig()
+    assert res.config.report_type == "xml"
+
+    pycoverage_config = {"project_root": "project/root", "report_type": "json"}
+    res = _get_plugin({"plugins": {"pycoverage": pycoverage_config}}, "pycoverage")
+    assert isinstance(res, Pycoverage)
+    assert res.config == PycoverageConfig(pycoverage_config)
+    assert res.config.report_type == "json"
 
 
 def test_select_preparation_plugins(mocker):

--- a/tests/plugins/test_pycoverage.py
+++ b/tests/plugins/test_pycoverage.py
@@ -1,5 +1,9 @@
+import pathlib
+from unittest.mock import MagicMock
+
 import pytest
 
+from codecov_cli.helpers.folder_searcher import globs_to_regex
 from codecov_cli.plugins.pycoverage import Pycoverage
 
 
@@ -12,6 +16,18 @@ def xml_subprocess_mock(mocker):
     yield mocker.patch(
         "codecov_cli.plugins.pycoverage.subprocess.run",
         side_effect=xml_subprocess_side_effect,
+    )
+
+
+@pytest.fixture
+def json_subprocess_mock(mocker):
+    def json_subprocess_side_effect(*args, cwd, **kwargs):
+        (cwd / "coverage.json").touch()
+        return mocker.MagicMock(stdout=b"Wrote JSON report to coverage.json\n")
+
+    yield mocker.patch(
+        "codecov_cli.plugins.pycoverage.subprocess.run",
+        side_effect=json_subprocess_side_effect,
     )
 
 
@@ -40,11 +56,49 @@ def mocked_generator(mocker):
     )
 
 
-class TestPycoverage(object):
+class TestPycoveragePathToCoverage(object):
+    def test_path_from_config(self, tmp_path, mocker):
+        (tmp_path / ".coverage").touch()
+        config = {
+            "project_root": tmp_path,
+            "path_to_coverage_file": pathlib.Path.joinpath(tmp_path, ".coverage"),
+        }
+        plugin = Pycoverage(config)
+
+        mock_search_path = mocker.patch("codecov_cli.plugins.pycoverage.search_files")
+        path = plugin._get_path_to_coverage()
+        assert path == pathlib.Path.joinpath(tmp_path, ".coverage")
+        assert path.parent == tmp_path
+        mock_search_path.assert_not_called()
+
+    def test_path_from_config_fallback(self, tmp_path, mocker):
+        config = {
+            "project_root": tmp_path,
+            "path_to_coverage_file": pathlib.Path.joinpath(tmp_path, ".coverage"),
+        }
+        plugin = Pycoverage(config)
+
+        mock_search_path_return = MagicMock()
+        mock_search_path = mocker.patch(
+            "codecov_cli.plugins.pycoverage.search_files",
+            return_value=mock_search_path_return,
+        )
+        path = plugin._get_path_to_coverage()
+        mock_search_path.assert_called_with(
+            tmp_path,
+            [],
+            filename_include_regex=globs_to_regex([".coverage", ".coverage.*"]),
+            filename_exclude_regex=None,
+        )
+        assert path == mock_search_path_return.__next__.return_value
+
+
+class TestPycoverageXMLReportGeneration(object):
     def test_coverage_combine_called_if_coverage_data_exist(
         self, tmp_path, mocker, combine_subprocess_mock
     ):
-        Pycoverage(tmp_path)._generate_XML_report(tmp_path)
+        config = {"project_root": tmp_path}
+        Pycoverage(config)._generate_XML_report(tmp_path)
         assert not combine_subprocess_mock.called
 
         combine_subprocess_mock.reset_mock()
@@ -54,7 +108,7 @@ class TestPycoverage(object):
             p = tmp_path / name
             p.touch()
 
-        Pycoverage(tmp_path)._generate_XML_report(tmp_path)
+        Pycoverage(config)._generate_XML_report(tmp_path)
 
         combine_subprocess_mock.assert_any_call(
             ["coverage", "combine", "-a"], cwd=tmp_path
@@ -64,29 +118,56 @@ class TestPycoverage(object):
     def test_xml_reports_generated_if_coverage_file_exists(
         self, tmp_path, mocker, xml_subprocess_mock
     ):
-
-        Pycoverage(tmp_path)._generate_XML_report(tmp_path)
+        config = {"project_root": tmp_path}
+        Pycoverage(config)._generate_XML_report(tmp_path)
         xml_subprocess_mock.assert_not_called()
 
+        config = {"project_root": tmp_path}
         (tmp_path / ".coverage").touch()
-        Pycoverage(tmp_path)._generate_XML_report(tmp_path)
+        Pycoverage(config)._generate_XML_report(tmp_path)
         xml_subprocess_mock.assert_called_with(
             ["coverage", "xml", "-i"], cwd=tmp_path, capture_output=True
         )
         assert (tmp_path / ".coverage").exists()
 
-    def test_run_preparation_creates_nothing_if_nothing(
-        self, mocked_generator, tmp_path, mocker
-    ):
-        Pycoverage(tmp_path).run_preparation(None)
-        assert not (tmp_path / "coverage.xml").exists()
-        assert not mocked_generator.called
 
+class TestPycoverageJSONReportGeneration(object):
+    def test_report_not_generated_if_coverage_not_there(
+        self, tmp_path, mocker, json_subprocess_mock
+    ):
+        config = {"project_root": tmp_path}
+        Pycoverage(config)._generate_JSON_report(tmp_path)
+        json_subprocess_mock.assert_not_called()
+
+    def test_reports_generated_if_coverage_file_exists(
+        self, tmp_path, mocker, json_subprocess_mock
+    ):
+        config = {"project_root": tmp_path}
+        (tmp_path / ".coverage").touch()
+        Pycoverage(config)._generate_JSON_report(tmp_path)
+        json_subprocess_mock.assert_called_with(
+            ["coverage", "json", "--show-contexts"], cwd=tmp_path, capture_output=True
+        )
+        assert (tmp_path / ".coverage").exists()
+
+    def test_reports_generated_with_no_context_if_option(
+        self, tmp_path, mocker, json_subprocess_mock
+    ):
+        config = {"project_root": tmp_path, "include_contexts": False}
+        (tmp_path / ".coverage").touch()
+        Pycoverage(config)._generate_JSON_report(tmp_path)
+        json_subprocess_mock.assert_called_with(
+            ["coverage", "json"], cwd=tmp_path, capture_output=True
+        )
+
+
+class TestPycoverageRunPreparation(object):
     def test_run_preparation_creates_reports_in_root_dir(
         self, mocked_generator, tmp_path, mocker
     ):
         (tmp_path / ".coverage").touch()
-        Pycoverage(tmp_path).run_preparation(None)
+        config = {"project_root": tmp_path}
+        Pycoverage(config).run_preparation(None)
         assert (tmp_path / "coverage.xml").exists()
         mocked_generator.assert_called_with(tmp_path)
 
@@ -95,7 +176,8 @@ class TestPycoverage(object):
     ):
         (tmp_path / "sub").mkdir()
         (tmp_path / "sub" / ".coverage").touch()
-        Pycoverage(tmp_path).run_preparation(None)
+        config = {"project_root": tmp_path}
+        Pycoverage(config).run_preparation(None)
 
         assert (tmp_path / "sub" / "coverage.xml").exists()
         mocked_generator.assert_called_with(tmp_path / "sub")
@@ -104,5 +186,14 @@ class TestPycoverage(object):
         self, tmp_path, mocker, mocked_generator
     ):
         mocker.patch("codecov_cli.plugins.pycoverage.shutil.which", return_value=None)
-        Pycoverage(tmp_path).run_preparation(None)
+        config = {"project_root": tmp_path}
+        Pycoverage(config).run_preparation(None)
+        assert not mocked_generator.called
+
+    def test_run_preparation_creates_nothing_if_nothing(
+        self, mocked_generator, tmp_path, mocker
+    ):
+        config = {"project_root": tmp_path}
+        Pycoverage(config).run_preparation(None)
+        assert not (tmp_path / "coverage.xml").exists()
         assert not mocked_generator.called


### PR DESCRIPTION
These changes improve the existing Pycoverage plugin.
This plugin runs `coverage` util (from pytest-cov) to generate human-readable reports from .coverage files.

Up to this point it would generate XML files. But it can also generate JSON files.
This is relevant because ATS uses the JSON format. So far we've been telling users to add another step
to their CI to create the files directly calling `coverage`, but the plugin can handle it for us.

In these changes we include config options that allow us to decide what report file to generate,
plus other things like giving the path directly, and options specific to the JSON reports.