### PR TITLE
Create plugin to compress ATS reports

### DIFF
--- a/.github/workflows/push_flow.yml
+++ b/.github/workflows/push_flow.yml
@@ -39,8 +39,8 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        python setup.py develop
         pip install -r requirements.txt
+        python setup.py develop
     - name: Create commit in codecov
       run: |
         codecovcli create-commit -t ${{ secrets.CODECOV_TOKEN }} --git-service github

--- a/codecov_cli/plugins/__init__.py
+++ b/codecov_cli/plugins/__init__.py
@@ -4,6 +4,7 @@ from importlib import import_module
 
 import click
 
+from codecov_cli.plugins.compress_pycoverage_contexts import CompressPycoverageContexts
 from codecov_cli.plugins.gcov import GcovPlugin
 from codecov_cli.plugins.pycoverage import Pycoverage
 from codecov_cli.plugins.xcode import XcodePlugin
@@ -54,6 +55,9 @@ def _get_plugin(cli_config, plugin_name):
         return Pycoverage(config)
     if plugin_name == "xcode":
         return XcodePlugin()
+    if plugin_name == "compress-pycoverage":
+        config = cli_config.get("plugins", {}).get("compress-pycoverage", {})
+        return CompressPycoverageContexts(config)
     if cli_config and plugin_name in cli_config.get("plugins", {}):
         return _load_plugin_from_yaml(cli_config["plugins"][plugin_name])
     click.secho(f"Unable to find plugin {plugin_name}", fg="magenta", err=True)

--- a/codecov_cli/plugins/compress_pycoverage_contexts.py
+++ b/codecov_cli/plugins/compress_pycoverage_contexts.py
@@ -1,0 +1,140 @@
+import json
+import logging
+import pathlib
+from decimal import Decimal
+from typing import Any, List
+
+import ijson
+from smart_open import open
+
+from codecov_cli.plugins.types import PreparationPluginReturn
+
+logger = logging.getLogger("codecovcli")
+
+
+class Encoder(json.JSONEncoder):
+    def default(self, o: Any) -> Any:
+        if isinstance(o, Decimal):
+            return str(o)
+        return super().default(o)
+
+
+class CompressPycoverageContextsConfig(dict):
+    @property
+    def file_to_compress(self) -> pathlib.Path:
+        """
+        The report file to compress.
+        file_to_compress: Union[str, pathlib.Path] [default coverage.json]
+        """
+        return pathlib.Path(self.get("file_to_compress", "coverage.json"))
+
+    @property
+    def delete_uncompressed(self) -> bool:
+        """
+        Flag indicating to delete the original file after compressing.
+        Recommended to avoid uploading the uncompressed file.
+        delete_uncompressed: bool [default True]
+        """
+        return self.get("delete_uncompressed", True)
+
+
+class CompressPycoverageContexts(object):
+    def __init__(self, config: dict = None) -> None:
+        if config is None:
+            config = {}
+        self.config = CompressPycoverageContextsConfig(config)
+        self.file_to_compress = self.config.file_to_compress
+        self.file_to_write = pathlib.Path(
+            str(self.file_to_compress).replace(".json", "") + ".codecov.json"
+        )
+
+    def run_preparation(self, collector) -> PreparationPluginReturn:
+        if not self.file_to_compress.exists():
+            logger.warning(
+                f"File to compress {self.file_to_compress} not found. Aborting"
+            )
+            return PreparationPluginReturn(
+                success=False,
+                messages=[f"File to compress {self.file_to_compress} not found."],
+            )
+        if not self.file_to_compress.is_file():
+            logger.warning(
+                f"File to compress {self.file_to_compress} is not a file. Aborting"
+            )
+            return PreparationPluginReturn(
+                success=False,
+                messages=[f"File to compress {self.file_to_compress} is not a file."],
+            )
+        # Create in and out streams
+        fd_in = open(self.file_to_compress, "rb")
+        fd_out = open(self.file_to_write, "w")
+        # Compress the file
+        fd_out.write("{")
+        self._copy_meta(fd_in, fd_out)
+        files_in_report = ijson.kvitems(fd_in, "files")
+        self._compress_files(files_in_report, fd_out)
+        fd_out.write("}")
+        # Close streams
+        fd_in.close()
+        fd_out.close()
+        logger.info(f"Compressed report written to {self.file_to_write}")
+        # Delete original file if needed
+        if self.config.delete_uncompressed:
+            logger.info(f"Deleting file {self.file_to_compress}")
+            self.file_to_compress.unlink()
+        return PreparationPluginReturn(success=True, messages=[])
+
+    def _compress_files(self, files_in_report, fd_out) -> None:
+        """
+        Compress the 'files' entry in the coverage data.
+        This is done by creating a labels table [str -> int] mapping labels to an index.
+        This index then substitutes the label itself in the contexts
+        """
+        labels_table = {}
+        nxt_idx = 0
+
+        fd_out.write('"files":{')
+        for file_name, file_coverage_details in files_in_report:
+            self._copy_file_details(file_name, file_coverage_details, fd_out)
+            fd_out.write('"contexts": {')
+            contexts = file_coverage_details["contexts"]
+            for line_number, labels in contexts.items():
+                fd_out.write(f'"{line_number}":')
+                new_labels = []
+                for label in labels:
+                    stripped_label = label.split("|")[0]  # removes '|run' from label
+                    if stripped_label not in labels_table:
+                        labels_table[stripped_label] = nxt_idx
+                        nxt_idx += 1
+                    new_labels.append(labels_table[stripped_label])
+                fd_out.write(json.dumps(new_labels))
+                # fd_out.write(self._bitmask_label_indexes(new_labels))
+                fd_out.write(",")
+            if len(contexts):  # Avoid removing '{' if contexts == {}
+                # Because there will be an extra ',' after the last line
+                fd_out.seek(fd_out.tell() - 1)
+            # One curly brace for the 'contexts', one for the file_name
+            fd_out.write("}},")
+        # Because there will be an extra ',' after the last file_name
+        fd_out.seek(fd_out.tell() - 1)
+        fd_out.write("},")
+        # Save the inverted index of labels table in the report
+        # So when we are processing the result we have int -> label
+        fd_out.write(
+            f'"labels_table": {json.dumps({ value: key for key, value in labels_table.items() })}'
+        )
+
+    def _copy_file_details(self, file_name, file_details, fd_out) -> None:
+        fd_out.write(f'"{file_name}":{{')
+        fd_out.write(f'"executed_lines": {file_details["executed_lines"]},')
+        fd_out.write(f'"summary": {json.dumps(file_details["summary"], cls=Encoder)},')
+        fd_out.write(f'"missing_lines": {file_details["missing_lines"]},')
+        fd_out.write(f'"excluded_lines": {file_details["excluded_lines"]},')
+
+    def _copy_meta(self, fd_in, fd_out) -> None:
+        meta = ijson.kvitems(fd_in, "")
+        for key, value in meta:
+            if key == "files":
+                continue
+            fd_out.write(f'"{key}": {json.dumps(value, cls=Encoder)},')
+        fd_in.seek(0)

--- a/requirements.in
+++ b/requirements.in
@@ -7,3 +7,5 @@ pyyaml
 responses
 httpx
 tree_sitter
+ijson
+smart-open

--- a/requirements.txt
+++ b/requirements.txt
@@ -30,6 +30,8 @@ idna==3.3
     #   anyio
     #   requests
     #   rfc3986
+ijson==3.2.0.post0
+    # via -r requirements.in
 iniconfig==1.1.1
     # via pytest
 packaging==21.3
@@ -60,6 +62,8 @@ responses==0.21.0
     # via -r requirements.in
 rfc3986[idna2008]==1.5.0
     # via httpx
+smart-open==6.3.0
+    # via -r requirements.in
 sniffio==1.3.0
     # via
     #   anyio

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ setup(
     long_description_content_type='text/markdown',
     author="Codecov",
     author_email="support@codecov.io",
-    install_requires=["click", "requests", "PyYAML", "tree_sitter", "httpx"],
+    install_requires=["click", "requests", "PyYAML", "tree_sitter", "httpx", "pytest", "pytest-cov", "ijson", "smart-open"],
     entry_points={
         "console_scripts": [
             "codecovcli = codecov_cli.main:run",

--- a/tests/plugins/test_compress_pycoverage_contexts.py
+++ b/tests/plugins/test_compress_pycoverage_contexts.py
@@ -1,0 +1,311 @@
+import json
+import pathlib
+from io import BytesIO
+from unittest.mock import call
+
+import pytest
+
+from codecov_cli.plugins.compress_pycoverage_contexts import CompressPycoverageContexts
+from codecov_cli.plugins.types import PreparationPluginReturn
+
+sample = {
+    "meta": {
+        "version": "6.5.0",
+        "timestamp": "2023-05-15T18:35:30.641570",
+        "branch_coverage": False,
+        "show_contexts": True,
+    },
+    "totals": {
+        "covered_lines": 416,
+        "num_statements": 437,
+        "percent_covered": 95.19450800915332,
+        "percent_covered_display": "95",
+        "missing_lines": 21,
+        "excluded_lines": 0,
+    },
+    "files": {
+        "awesome.py": {
+            "executed_lines": [1, 2, 3, 5],
+            "summary": {
+                "covered_lines": 4,
+                "num_statements": 5,
+                "percent_covered": 80.0,
+                "percent_covered_display": "80",
+                "missing_lines": 1,
+                "excluded_lines": 0,
+            },
+            "missing_lines": [4],
+            "excluded_lines": [],
+            "contexts": {
+                "1": [""],
+                "2": ["label_1|run", "label_2|run"],
+                "3": ["label_2|run", "label_3|run"],
+                "5": ["label_5|run"],
+            },
+        },
+        "__init__.py": {
+            "executed_lines": [],
+            "summary": {
+                "covered_lines": 0,
+                "num_statements": 4,
+                "percent_covered": 0.0,
+                "percent_covered_display": "0",
+                "missing_lines": 4,
+                "excluded_lines": 0,
+            },
+            "missing_lines": [1, 3, 4, 5],
+            "excluded_lines": [],
+            "contexts": {},
+        },
+    },
+}
+
+
+class TestCompressPycoverageContexts_CompressionFunctions(object):
+    def test_copy_meta(self, mocker):
+        fd_in_mock = BytesIO(bytearray(json.dumps(sample), encoding="utf-8"))
+        fd_out_mock = mocker.MagicMock()
+        plugin = CompressPycoverageContexts()
+        plugin._copy_meta(fd_in_mock, fd_out_mock)
+        fd_out_mock.write.assert_has_calls(
+            [
+                call(
+                    '"meta": {"version": "6.5.0", "timestamp": "2023-05-15T18:35:30.641570", "branch_coverage": false, "show_contexts": true},'
+                ),
+                call(
+                    '"totals": {"covered_lines": 416, "num_statements": 437, "percent_covered": "95.19450800915332", "percent_covered_display": "95", "missing_lines": 21, "excluded_lines": 0},'
+                ),
+            ],
+            any_order=True,
+        )
+
+    def test_copy_file_details(self, mocker):
+        fd_out_mock = mocker.MagicMock()
+        file_name = "awesome.py"
+        file_details = sample["files"][file_name]
+        plugin = CompressPycoverageContexts()
+        plugin._copy_file_details(file_name, file_details, fd_out_mock)
+        fd_out_mock.write.assert_has_calls(
+            [
+                call('"awesome.py":{'),
+                call('"executed_lines": [1, 2, 3, 5],'),
+                call(
+                    '"summary": {"covered_lines": 4, "num_statements": 5, "percent_covered": 80.0, "percent_covered_display": "80", "missing_lines": 1, "excluded_lines": 0},'
+                ),
+                call('"missing_lines": [4],'),
+                call('"excluded_lines": [],'),
+            ]
+        )
+
+    def test_compress_files(self, mocker):
+        out_stream = ""
+
+        def write_side_effect(msg):
+            nonlocal out_stream
+            out_stream += str(msg)
+
+        def seek_site_effect(offset):
+            nonlocal out_stream
+            out_stream = out_stream[:offset]
+
+        fd_out_mock = mocker.MagicMock()
+        fd_out_mock.write.side_effect = write_side_effect
+        fd_out_mock.tell.side_effect = lambda: len(out_stream)
+        fd_out_mock.seek.side_effect = seek_site_effect
+
+        files_in_report = [
+            ("awesome.py", sample["files"]["awesome.py"]),
+            ("__init__.py", sample["files"]["__init__.py"]),
+        ]
+
+        expected_output = {
+            "files": {
+                "awesome.py": {
+                    "executed_lines": [1, 2, 3, 5],
+                    "summary": {
+                        "covered_lines": 4,
+                        "num_statements": 5,
+                        "percent_covered": 80.0,
+                        "percent_covered_display": "80",
+                        "missing_lines": 1,
+                        "excluded_lines": 0,
+                    },
+                    "missing_lines": [4],
+                    "excluded_lines": [],
+                    "contexts": {
+                        "1": [0],
+                        "2": [1, 2],
+                        "3": [2, 3],
+                        "5": [4],
+                    },
+                },
+                "__init__.py": {
+                    "executed_lines": [],
+                    "summary": {
+                        "covered_lines": 0,
+                        "num_statements": 4,
+                        "percent_covered": 0.0,
+                        "percent_covered_display": "0",
+                        "missing_lines": 4,
+                        "excluded_lines": 0,
+                    },
+                    "missing_lines": [1, 3, 4, 5],
+                    "excluded_lines": [],
+                    "contexts": {},
+                },
+            },
+            "labels_table": {
+                "0": "",
+                "1": "label_1",
+                "2": "label_2",
+                "3": "label_3",
+                "4": "label_5",
+            },
+        }
+        plugin = CompressPycoverageContexts()
+        plugin._compress_files(files_in_report, fd_out_mock)
+        print(out_stream)
+        assert json.loads("{" + out_stream + "}") == expected_output
+
+
+class TestCompressPycoverageContexts(object):
+    def test_default_options(self):
+        plugin = CompressPycoverageContexts()
+        assert plugin.config.file_to_compress == pathlib.Path("coverage.json")
+        assert plugin.config.delete_uncompressed == True
+        assert plugin.file_to_compress == pathlib.Path("coverage.json")
+        assert plugin.file_to_write == pathlib.Path("coverage.codecov.json")
+
+    def test_change_options(self):
+        config = {
+            "file_to_compress": "label.coverage.json",
+            "delete_uncompressed": False,
+        }
+        plugin = CompressPycoverageContexts(config)
+        assert plugin.config.file_to_compress == pathlib.Path("label.coverage.json")
+        assert plugin.config.delete_uncompressed == False
+        assert plugin.file_to_compress == pathlib.Path("label.coverage.json")
+        assert plugin.file_to_write == pathlib.Path("label.coverage.codecov.json")
+
+    def test_run_preparation_fail_fast_no_file(self):
+        plugin = CompressPycoverageContexts()
+        res = plugin.run_preparation(None)
+        assert res == PreparationPluginReturn(
+            success=False,
+            messages=[f"File to compress coverage.json not found."],
+        )
+
+    def test_run_preparation_fail_fast_path_not_file(self, tmp_path):
+        config = {"file_to_compress": tmp_path}
+        plugin = CompressPycoverageContexts(config)
+        res = plugin.run_preparation(None)
+        assert res == PreparationPluginReturn(
+            success=False,
+            messages=[f"File to compress {tmp_path} is not a file."],
+        )
+
+    def test_run_preparation_mocked(self, tmp_path, mocker):
+        (tmp_path / "coverage.json").touch()
+        mock_fd_in = mocker.MagicMock()
+        mock_fd_out = mocker.MagicMock()
+        mock_smart_open = mocker.patch(
+            "codecov_cli.plugins.compress_pycoverage_contexts.open",
+            side_effect=[mock_fd_in, mock_fd_out],
+        )
+        mock_ijson = mocker.patch(
+            "codecov_cli.plugins.compress_pycoverage_contexts.ijson"
+        )
+        mock_ijson.kvitems.return_value = "files_in_report"
+        mock_copy_meta = mocker.patch.object(CompressPycoverageContexts, "_copy_meta")
+        mock_compress_files = mocker.patch.object(
+            CompressPycoverageContexts, "_compress_files"
+        )
+
+        config = {"file_to_compress": (tmp_path / "coverage.json")}
+        plugin = CompressPycoverageContexts(config)
+        res = plugin.run_preparation(None)
+        assert res == PreparationPluginReturn(success=True, messages=[])
+        mock_smart_open.assert_has_calls(
+            [
+                call((tmp_path / "coverage.json"), "rb"),
+                call((tmp_path / "coverage.codecov.json"), "w"),
+            ]
+        )
+        mock_copy_meta.assert_called_with(mock_fd_in, mock_fd_out)
+        mock_ijson.kvitems.assert_called_with(mock_fd_in, "files")
+        mock_compress_files.assert_called_with("files_in_report", mock_fd_out)
+        mock_fd_in.close.assert_called()
+        mock_fd_out.close.assert_called()
+        mock_fd_out.write.assert_has_calls([call("{"), call("}")])
+        assert not (tmp_path / "coverage.json").exists()
+
+    def test_run_preparation_sample(self, tmp_path):
+        file_to_compress = tmp_path / "coverage.json"
+        file_to_compress.write_text(json.dumps(sample))
+        config = {"file_to_compress": file_to_compress}
+        plugin = CompressPycoverageContexts(config)
+        res = plugin.run_preparation(None)
+        assert res == PreparationPluginReturn(success=True, messages=[])
+        assert not file_to_compress.exists()
+        expected_file = tmp_path / "coverage.codecov.json"
+        assert expected_file.exists()
+        result = json.loads(expected_file.read_text())
+        print(result)
+        assert result == {
+            "meta": {
+                "version": "6.5.0",
+                "timestamp": "2023-05-15T18:35:30.641570",
+                "branch_coverage": False,
+                "show_contexts": True,
+            },
+            "totals": {
+                "covered_lines": 416,
+                "num_statements": 437,
+                "percent_covered": "95.19450800915332",
+                "percent_covered_display": "95",
+                "missing_lines": 21,
+                "excluded_lines": 0,
+            },
+            "files": {
+                "awesome.py": {
+                    "executed_lines": [1, 2, 3, 5],
+                    "summary": {
+                        "covered_lines": 4,
+                        "num_statements": 5,
+                        "percent_covered": "80.0",
+                        "percent_covered_display": "80",
+                        "missing_lines": 1,
+                        "excluded_lines": 0,
+                    },
+                    "missing_lines": [4],
+                    "excluded_lines": [],
+                    "contexts": {
+                        "1": [0],
+                        "2": [1, 2],
+                        "3": [2, 3],
+                        "5": [4],
+                    },
+                },
+                "__init__.py": {
+                    "executed_lines": [],
+                    "summary": {
+                        "covered_lines": 0,
+                        "num_statements": 4,
+                        "percent_covered": "0.0",
+                        "percent_covered_display": "0",
+                        "missing_lines": 4,
+                        "excluded_lines": 0,
+                    },
+                    "missing_lines": [1, 3, 4, 5],
+                    "excluded_lines": [],
+                    "contexts": {},
+                },
+            },
+            "labels_table": {
+                "0": "",
+                "1": "label_1",
+                "2": "label_2",
+                "3": "label_3",
+                "4": "label_5",
+            },
+        }

--- a/tests/plugins/test_instantiation.py
+++ b/tests/plugins/test_instantiation.py
@@ -6,6 +6,7 @@ from codecov_cli.plugins import (
     _load_plugin_from_yaml,
     select_preparation_plugins,
 )
+from codecov_cli.plugins.compress_pycoverage_contexts import CompressPycoverageContexts
 from codecov_cli.plugins.pycoverage import Pycoverage, PycoverageConfig
 
 
@@ -64,6 +65,18 @@ def test_get_plugin_pycoverage():
     assert isinstance(res, Pycoverage)
     assert res.config == PycoverageConfig(pycoverage_config)
     assert res.config.report_type == "json"
+
+
+def test_get_plugin_compress_pycoverage():
+    res = _get_plugin({}, "compress-pycoverage")
+    assert isinstance(res, CompressPycoverageContexts)
+
+    res = _get_plugin(
+        {"plugins": {"compress-pycoverage": {"file_to_compress": "something.json"}}},
+        "compress-pycoverage",
+    )
+    assert isinstance(res, CompressPycoverageContexts)
+    assert str(res.file_to_compress) == "something.json"
 
 
 def test_select_preparation_plugins(mocker):


### PR DESCRIPTION
Recently we've noticed that JSON reports with labels - the one format accepted by ATS -
are simply too big. It is likely that we are experiencing Out Of Memory errors when
trying to process them.
    
To put it in perspective, below is a comparison between reports with no labels and
with labels for the worker repo full test suite.
```
  918951 bytes (897Kb) May 15 19:45 coverage.xml # this is the regular coverage with no labels
26607438 bytes (25Mb)  May 15 19:48 label.coverage.json # this is all labels, stock
```
    
To avoid processing issues and save bandwidth and all that we will be compressing these reports.
The compression idea is simple: we build a mapping label --> int that will substitute the label itself
in the report (usually large-ish strings) for a number in the "contexts" of each file.
We then include the reverse mapping in the report (int --> label) so that we can easily parse
the compressed report when processing it.
    
This is done via the new `compress_pycoverage_contexts` plugin that can be used when uploading
with the CLI. Notice that the process is transparent for the user.
The results are promissing. Compressing the worker repo (25Mb) yields a new report with 801Kb.
    
About the new requirements.
These libs allow streaming large files (smart_open) and stream-parsing the JSON (ijson)
This means we don't ever load the full big report in memory when compressing it,
avoiding the Out Of Memory error in the plugin as well.