### PR TITLE
Enable other runners (DAN runner)

### DIFF
--- a/codecov_cli/commands/labelanalysis.py
+++ b/codecov_cli/commands/labelanalysis.py
@@ -32,6 +32,7 @@ logger = logging.getLogger("codecovcli")
     cls=CodecovOption,
     required=True,
 )
+@click.option("--runner-name", "--runner", "runner_name", help="Runner to use")
 @click.pass_context
 def label_analysis(
     ctx: click.Context,

--- a/codecov_cli/commands/labelanalysis.py
+++ b/codecov_cli/commands/labelanalysis.py
@@ -32,14 +32,16 @@ logger = logging.getLogger("codecovcli")
     cls=CodecovOption,
     required=True,
 )
-@click.option("--runner-name", "--runner", "runner_name", help="Runner to use")
+@click.option(
+    "--runner-name", "--runner", "runner_name", help="Runner to use", default="python"
+)
 @click.pass_context
 def label_analysis(
     ctx: click.Context,
     token: str,
     head_commit_sha: str,
     base_commit_sha: str,
-    runner_name: str = "python",
+    runner_name: str,
 ):
     logger.debug(
         "Starting label analysis",

--- a/tests/commands/test_invoke_labelanalysis.py
+++ b/tests/commands/test_invoke_labelanalysis.py
@@ -21,15 +21,17 @@ class TestLabelAnalysisCommand(object):
 
         result = runner.invoke(cli, ["label-analysis", "--help"], obj={})
         assert result.exit_code == 0
+        print(result.output)
         assert result.output.split("\n") == [
             "Usage: cli label-analysis [OPTIONS]",
             "",
             "Options:",
-            "  --token TEXT     The static analysis token (NOT the same token as upload)",
-            "                   [required]",
-            "  --head-sha TEXT  Commit SHA (with 40 chars)  [required]",
-            "  --base-sha TEXT  Commit SHA (with 40 chars)  [required]",
-            "  --help           Show this message and exit.",
+            "  --token TEXT                  The static analysis token (NOT the same token as",
+            "                                upload)  [required]",
+            "  --head-sha TEXT               Commit SHA (with 40 chars)  [required]",
+            "  --base-sha TEXT               Commit SHA (with 40 chars)  [required]",
+            "  --runner-name, --runner TEXT  Runner to use",
+            "  --help                        Show this message and exit.",
             "",
         ]
 

--- a/tests/runners/test_dan_runner.py
+++ b/tests/runners/test_dan_runner.py
@@ -19,7 +19,7 @@ class TestDoAnythingNowRunner(object):
         runner = DoAnythingNowRunner(config_options)
         assert runner.params == config_options
         resp = runner.collect_tests()
-        assert resp.split() == test_list
+        assert resp == test_list
         mock_run.assert_called_with(
             ["mycommand", "--option"],
             capture_output=True,
@@ -54,7 +54,36 @@ class TestDoAnythingNowRunner(object):
         runner.process_labelanalysis_result(label_analysis_result)
         assert runner.params == config_options
         mock_run.assert_called_with(
-            ["mycommand", "--option"],
+            [
+                "mycommand",
+                "--option",
+                '{"present_report_labels": ["test_present"], "absent_labels": ["test_absent"], "present_diff_labels": ["test_in_diff"], "global_level_labels": ["test_global"]}',
+            ],
+            capture_output=True,
+            check=True,
+        )
+
+    @patch("codecov_cli.runners.dan_runner.subprocess.run")
+    def test_process_labelanalysis_result_string_command(self, mock_run):
+        label_analysis_result = {
+            "present_report_labels": ["test_present"],
+            "absent_labels": ["test_absent"],
+            "present_diff_labels": ["test_in_diff"],
+            "global_level_labels": ["test_global"],
+        }
+        cmd_output = "My command output"
+        mock_stdout = MagicMock()
+        mock_stdout.configure_mock(**{"stdout.decode.return_value": cmd_output})
+        mock_run.return_value = mock_stdout
+        config_options = {"process_labelanalysis_result_command": "mycommand --option"}
+        runner = DoAnythingNowRunner(config_options)
+        runner.process_labelanalysis_result(label_analysis_result)
+        assert runner.params == config_options
+        mock_run.assert_called_with(
+            [
+                "mycommand --option",
+                '{"present_report_labels": ["test_present"], "absent_labels": ["test_absent"], "present_diff_labels": ["test_in_diff"], "global_level_labels": ["test_global"]}',
+            ],
             capture_output=True,
             check=True,
         )


### PR DESCRIPTION
We had created a DAN runner previously, but there was no option in the label analysis
command to actually select different runners.

Another issue is that thwe return of `collect_tests` in a runner needs to be a list,
and the DAN runner was not returning that.

The changes here should make the DAN runner a viable alternative to the
PythonStandardRunner, in case we need that.