### PR TITLE
search for imports, add them to the JS analyzer

### DIFF
--- a/codecov_cli/services/staticanalysis/analyzers/general.py
+++ b/codecov_cli/services/staticanalysis/analyzers/general.py
@@ -54,3 +54,9 @@ class BaseAnalyzer(object):
         while cur:
             yield cur
             cur = cur.parent
+
+    def get_import_lines(self, root_node, imports_query):
+        import_lines = set()
+        for (a, _) in imports_query.captures(root_node):
+            import_lines.add((a.start_point[0] + 1, a.end_point[0] - a.start_point[0]))
+        return import_lines

--- a/codecov_cli/services/staticanalysis/analyzers/python/__init__.py
+++ b/codecov_cli/services/staticanalysis/analyzers/python/__init__.py
@@ -93,10 +93,9 @@ class PythonAnalyzer(BaseAnalyzer):
             self.definitions_lines.add(
                 (a.start_point[0] + 1, a.end_point[0] - a.start_point[0])
             )
-        for (a, _) in imports_query.captures(root_node):
-            self.import_lines.add(
-                (a.start_point[0] + 1, a.end_point[0] - a.start_point[0])
-            )
+
+        self.import_lines = self.get_import_lines(root_node, imports_query)
+
         h = hashlib.md5()
         h.update(self.actual_code)
         statements = sorted(

--- a/samples/example_module.js
+++ b/samples/example_module.js
@@ -1,0 +1,12 @@
+// Default export
+export default function greet(name) {
+    console.log(`Hello, ${name}!`);
+}
+  
+// Named exports
+export function sum(a, b) {
+    return a + b;
+}
+
+export const pi = 3.14159;
+  

--- a/samples/inputs/sample_003.js
+++ b/samples/inputs/sample_003.js
@@ -95,4 +95,34 @@ async function getData() {
   }
 }
 
+// Importing a default export
+import greet from '../example_module.js';
+
+// Importing named exports
+import { sum, pi } from '../example_module.js';
+
+// Importing a default export and renaming it
+import { default as renamedGreet } from '../example_module.js';
+
+// Importing everything from a module
+import * as moduleExports from '../example_module.js';
+
+// Importing a default export and specific named exports together
+import greet, { pi as constantPi } from '../example_module.js';
+
+//Dynamic import by using import(), which is different from the previous imports (static imports)
+let myModule;
+if (typeof window === "undefined") {
+  myModule = await import("../example_module.js");
+} else {
+  myModule = await import("../example_module.js");
+}
+greet('Alice');
+console.log(sum(2, 3));
+console.log(pi);
+console.log(renamedGreet('Bob'));
+console.log(moduleExports.sum(4, 5));
+console.log(moduleExports.pi);
+console.log(greet('Charlie'));
+console.log(constantPi);
 getData();

--- a/samples/outputs/sample_003.json
+++ b/samples/outputs/sample_003.json
@@ -17,13 +17,19 @@
             75,
             79,
             88,
-            97
+            97,
+            100,
+            103,
+            106,
+            109,
+            112
         ],
         "executable_lines": [],
-        "number_lines": 98,
-        "hash": "ad3f8572135398ba290dcb36ff0410c2",
+        "number_lines": 128,
+        "hash": "6cfa011ad0c3793848438c3fff8bd5b3",
         "filename": "samples/inputs/sample_003.js",
         "language": "javascript",
+        "import_lines": [[99, 0], [102, 0], [105, 0], [108, 0], [111, 0], [116, 0], [118, 0]],
         "functions": [
             {
                 "identifier": "myFunction",


### PR DESCRIPTION
This PR:
- moves getting the import lines to the base Analyzer
- adds a import_query_str for js that we use to search for import lines
- analyzer returns the import lines 
Note that JS has static and dynamic imports.[ Static imports](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/import) use import, when [dynamic imports](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/import) use import() 
imports_query_str = """
  (import_statement) @elemen ====> this is for static imports
  (import) @elemen =====> this is for dynamic imports 
"""
Ticket: [CODE-3136](https://codecovio.atlassian.net/browse/CODE-3136?atlOrigin=eyJpIjoiOTIyNDFmMTdhOWY0NGE1Y2JmMWYxZDZlNzkxNTdjMDYiLCJwIjoiaiJ9)

[CODE-3136]: https://codecovio.atlassian.net/browse/CODE-3136?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ