### PR TITLE
add all types of JS functions to function_query_str

### DIFF
--- a/codecov_cli/services/staticanalysis/analyzers/general.py
+++ b/codecov_cli/services/staticanalysis/analyzers/general.py
@@ -32,9 +32,11 @@ class BaseAnalyzer(object):
 
     def _get_name(self, node):
         name_node = node.child_by_field_name("name")
-        actual_name = self.actual_code[
-            name_node.start_byte : name_node.end_byte
-        ].decode()
+        actual_name = (
+            self.actual_code[name_node.start_byte : name_node.end_byte].decode()
+            if name_node
+            else "Anonymous"
+        )
         try:
             wrapping_class = next(
                 x for x in self._get_parent_chain(node) if x.type in self.wrappers

--- a/codecov_cli/services/staticanalysis/analyzers/javascript_es6/__init__.py
+++ b/codecov_cli/services/staticanalysis/analyzers/javascript_es6/__init__.py
@@ -7,6 +7,10 @@ from codecov_cli.services.staticanalysis.analyzers.general import BaseAnalyzer
 
 function_query_str = """
 (function_declaration) @elemen
+(generator_function_declaration) @elemen2
+(function) @elemen3
+(generator_function) @elemen4
+(arrow_function) @elemen5
 """
 
 method_query_str = """

--- a/codecov_cli/services/staticanalysis/analyzers/javascript_es6/__init__.py
+++ b/codecov_cli/services/staticanalysis/analyzers/javascript_es6/__init__.py
@@ -33,7 +33,14 @@ class ES6Analyzer(BaseAnalyzer):
         "do_statement",
     ]
 
-    wrappers = ["class_declaration", "function_declaration"]
+    wrappers = [
+        "class_declaration",
+        "function_declaration",
+        "generator_function_declaration",
+        "function",
+        "generator_function",
+        "arrow_function",
+    ]
 
     def __init__(self, path, actual_code, **options):
         self.actual_code = actual_code

--- a/samples/inputs/sample_004.js
+++ b/samples/inputs/sample_004.js
@@ -1,0 +1,35 @@
+function outerFunction() {
+  
+    function innerFunction() {
+      console.log("Inner function called");
+    }
+    innerFunction();
+  }
+  
+outerFunction();
+
+async function foo() {}
+
+class Foo {
+  async bar() {}
+}
+
+// arrow function 
+async (a) => { return foo; };
+
+// 
+async function* foo() { yield 1; }
+
+function a () { function b () {} function *c () {} class D {} return }
+
+[
+    function *() {},
+    function *generateStuff(arg1, arg2) {
+      yield;
+      yield arg2;
+      yield * foo();
+    }
+]
+
+var b = function() {};
+  

--- a/samples/outputs/sample_003.json
+++ b/samples/outputs/sample_003.json
@@ -68,7 +68,7 @@
                 }
             }, 
             {
-                "identifier": "fetchData::Anonymous", 
+                "identifier": "fetchData::Anonymous_82_4", 
                 "start_line": 82, 
                 "end_line": 86, 
                 "code_hash": "843009cc4a83d8d54e0e60e11212cad5", 
@@ -80,7 +80,7 @@
                 }
             },
             {
-                "identifier": "fetchData::Anonymous",
+                "identifier": "fetchData::Anonymous_82_4::Anonymous_83_2",
                 "start_line": 83,
                 "end_line": 85,
                 "code_hash": "06839ff9cb3f2f8253694bb9143c615d",

--- a/samples/outputs/sample_003.json
+++ b/samples/outputs/sample_003.json
@@ -68,6 +68,30 @@
                 }
             }, 
             {
+                "identifier": "fetchData::Anonymous", 
+                "start_line": 82, 
+                "end_line": 86, 
+                "code_hash": "843009cc4a83d8d54e0e60e11212cad5", 
+                "complexity_metrics": {
+                    "conditions": 0, 
+                    "mccabe_cyclomatic_complexity": 1, 
+                    "returns": 0, 
+                    "max_nested_conditional": 0
+                }
+            },
+            {
+                "identifier": "fetchData::Anonymous",
+                "start_line": 83,
+                "end_line": 85,
+                "code_hash": "06839ff9cb3f2f8253694bb9143c615d",
+                "complexity_metrics": {
+                    "conditions": 0,
+                    "mccabe_cyclomatic_complexity": 1,
+                    "returns": 0,
+                    "max_nested_conditional": 0
+                }
+            },
+            {
                 "identifier": "getData", 
                 "start_line": 89, 
                 "end_line": 96, "code_hash": "44721228ef36e7dd7702285c5609e092", 

--- a/samples/outputs/sample_004.json
+++ b/samples/outputs/sample_004.json
@@ -1,0 +1,161 @@
+{
+    "result": {
+        "empty_lines": [
+            2, 8, 10, 12, 16, 19, 22, 24, 33, 35
+        ],
+        "executable_lines": [],
+        "number_lines": 35,
+        "hash": "1ab313b3c1dd7f13c5beb09d99361481",
+        "filename": "samples/inputs/sample_004.js",
+        "language": "javascript",
+        "import_lines": [],
+        "functions": [
+            {
+                "identifier": "outerFunction", 
+                "start_line": 1, 
+                "end_line": 7, 
+                "code_hash": "410e3cdac877f4d4d96650fd2bdb7302", 
+                "complexity_metrics": {
+                    "conditions": 0, 
+                    "mccabe_cyclomatic_complexity": 1, 
+                    "returns": 0, 
+                    "max_nested_conditional": 0
+                }
+            }, 
+            {
+                "identifier": "outerFunction::innerFunction", 
+                "start_line": 3, 
+                "end_line": 5, 
+                "code_hash": "867352b5697c99ec8bf920eace84b90a", 
+                "complexity_metrics": {
+                    "conditions": 0, 
+                    "mccabe_cyclomatic_complexity": 1, 
+                    "returns": 0, 
+                    "max_nested_conditional": 0
+                }
+            }, 
+            {
+                "identifier": "foo", 
+                "start_line": 11, 
+                "end_line": 11, 
+                "code_hash": "99914b932bd37a50b983c5e7c90ae93b",
+                "complexity_metrics": {
+                    "conditions": 0, 
+                    "mccabe_cyclomatic_complexity": 1, 
+                    "returns": 0, 
+                    "max_nested_conditional": 0
+                    }
+                    }, 
+            {
+                "identifier": "Foo::bar", 
+                "start_line": 14, 
+                "end_line": 14, 
+                "code_hash": "99914b932bd37a50b983c5e7c90ae93b", 
+                "complexity_metrics": {
+                    "conditions": 0, 
+                    "mccabe_cyclomatic_complexity": 1, 
+                    "returns": 0, 
+                    "max_nested_conditional": 0
+                }
+            }, 
+            {
+                "identifier": "Anonymous", 
+                "start_line": 18, 
+                "end_line": 18, 
+                "code_hash": "8dd5ce440cc0dbf8e9b874e3a9a61951", 
+                "complexity_metrics": {
+                    "conditions": 0, 
+                    "mccabe_cyclomatic_complexity": 1, 
+                    "returns": 1, 
+                    "max_nested_conditional": 0
+                }
+            }, 
+            {
+                "identifier": "foo", 
+                "start_line": 21, 
+                "end_line": 21, 
+                "code_hash": "d858b03b04be75bf6f333641e8ef41a5", 
+                "complexity_metrics": {
+                    "conditions": 0, 
+                    "mccabe_cyclomatic_complexity": 1, 
+                    "returns": 0, 
+                    "max_nested_conditional": 0
+                }
+            }, 
+            {
+                "identifier": "a", 
+                "start_line": 23, 
+                "end_line": 23, 
+                "code_hash": "a9b5caf33c892637947990938210b544", 
+                "complexity_metrics": {
+                    "conditions": 0, 
+                    "mccabe_cyclomatic_complexity": 1, 
+                    "returns": 1, 
+                    "max_nested_conditional": 0
+                }
+            }, 
+            {
+                "identifier": "a::b", 
+                "start_line": 23, 
+                "end_line": 23, 
+                "code_hash": "99914b932bd37a50b983c5e7c90ae93b", 
+                "complexity_metrics": {
+                    "conditions": 0, 
+                    "mccabe_cyclomatic_complexity": 1, 
+                    "returns": 0, 
+                    "max_nested_conditional": 0
+                }
+            }, 
+            {
+                "identifier": "a::c", 
+                "start_line": 23, 
+                "end_line": 23, 
+                "code_hash": "99914b932bd37a50b983c5e7c90ae93b", 
+                "complexity_metrics": {
+                    "conditions": 0, 
+                    "mccabe_cyclomatic_complexity": 1, 
+                    "returns": 0, 
+                    "max_nested_conditional": 0
+                }
+            }, 
+            {
+                "identifier": "Anonymous", 
+                "start_line": 26, 
+                "end_line": 26, 
+                "code_hash": "99914b932bd37a50b983c5e7c90ae93b", 
+                "complexity_metrics": {
+                    "conditions": 0, 
+                    "mccabe_cyclomatic_complexity": 1, 
+                    "returns": 0, 
+                    "max_nested_conditional": 0
+                }
+            }, 
+            {
+                "identifier": "generateStuff", 
+                "start_line": 27, 
+                "end_line": 31, 
+                "code_hash": "e3ca3f85be0a1ca905c7b5d29c7dc070", 
+                "complexity_metrics": {
+                    "conditions": 0, 
+                    "mccabe_cyclomatic_complexity": 1,
+                    "returns": 0, 
+                    "max_nested_conditional": 0
+                }
+            }, 
+            {
+                "identifier": "Anonymous", 
+                "start_line": 34, 
+                "end_line": 34, 
+                "code_hash": "99914b932bd37a50b983c5e7c90ae93b", 
+                "complexity_metrics": {
+                    "conditions": 0, 
+                    "mccabe_cyclomatic_complexity": 1, 
+                    "returns": 0, 
+                    "max_nested_conditional": 0
+                }
+            }
+        ]  
+    },
+    "error": null  
+}
+

--- a/samples/outputs/sample_004.json
+++ b/samples/outputs/sample_004.json
@@ -59,7 +59,7 @@
                 }
             }, 
             {
-                "identifier": "Anonymous", 
+                "identifier": "Anonymous_18_0", 
                 "start_line": 18, 
                 "end_line": 18, 
                 "code_hash": "8dd5ce440cc0dbf8e9b874e3a9a61951", 
@@ -119,7 +119,7 @@
                 }
             }, 
             {
-                "identifier": "Anonymous", 
+                "identifier": "Anonymous_26_0", 
                 "start_line": 26, 
                 "end_line": 26, 
                 "code_hash": "99914b932bd37a50b983c5e7c90ae93b", 
@@ -143,7 +143,7 @@
                 }
             }, 
             {
-                "identifier": "Anonymous", 
+                "identifier": "Anonymous_34_0", 
                 "start_line": 34, 
                 "end_line": 34, 
                 "code_hash": "99914b932bd37a50b983c5e7c90ae93b", 

--- a/tests/services/static_analysis/test_analyse_file.py
+++ b/tests/services/static_analysis/test_analyse_file.py
@@ -17,6 +17,7 @@ here_parent = here.parent
         ("samples/inputs/sample_001.py", "samples/outputs/sample_001.json"),
         ("samples/inputs/sample_002.py", "samples/outputs/sample_002.json"),
         ("samples/inputs/sample_003.js", "samples/outputs/sample_003.json"),
+        ("samples/inputs/sample_004.js", "samples/outputs/sample_004.json"),
     ],
 )
 def test_sample_analysis(input_filename, output_filename):


### PR DESCRIPTION
JS has different types of functions
1- Function Declarations: These are defined with the function keyword. They are identified by `function_declaration`
example:
```
function add(a, b) {
  return a + b;
}
```
2- Function expressions: These are functions that are assigned to variables or other data structures. They are identified by `function`
example: 
`var b = function() {};`
3- Arrow Functions: These are a shorthand syntax for writing functions in JavaScript. They are identified by `arrow_function` 
example:
`async (a) => { return foo; };`
4-Generator Functions: These are special functions that can be paused and resumed. They are defined using the `function* `syntax and use the yield keyword. Identified by `generator_function_declaration`
example:
`async function* foo() { yield 1; }`
5- Another Generator function type. A generator function assigned to a variable. Identified by `generator_function`
example:
```
[
    function *() {},
    function *generateStuff(arg1, arg2) {
      yield;
      yield arg2;
      yield * foo();
    }
]
```

Also, some functions don't have a name, like arrow functions. So giving them "anonymous" as a name 
Ticket: [CODE-3136](https://codecovio.atlassian.net/browse/CODE-3136?atlOrigin=eyJpIjoiOTIyNDFmMTdhOWY0NGE1Y2JmMWYxZDZlNzkxNTdjMDYiLCJwIjoiaiJ9)

[CODE-3136]: https://codecovio.atlassian.net/browse/CODE-3136?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ