### PR TITLE
Add --max-wait-time option for label analysis

### DIFF
--- a/codecov_cli/commands/labelanalysis.py
+++ b/codecov_cli/commands/labelanalysis.py
@@ -1,12 +1,16 @@
 import logging
 import time
+from typing import List
 
 import click
 import requests
 
 from codecov_cli.fallbacks import CodecovOption, FallbackFieldEnum
 from codecov_cli.runners import get_runner
-from codecov_cli.runners.types import LabelAnalysisRequestResult
+from codecov_cli.runners.types import (
+    LabelAnalysisRequestResult,
+    LabelAnalysisRunnerInterface,
+)
 
 logger = logging.getLogger("codecovcli")
 
@@ -35,6 +39,13 @@ logger = logging.getLogger("codecovcli")
 @click.option(
     "--runner-name", "--runner", "runner_name", help="Runner to use", default="python"
 )
+@click.option(
+    "--max-wait-time",
+    "max_wait_time",
+    help="Max time (in seconds) to wait for the label analysis result before falling back to running all tests. Default is to wait forever.",
+    default=None,
+    type=int,
+)
 @click.pass_context
 def label_analysis(
     ctx: click.Context,
@@ -42,6 +53,7 @@ def label_analysis(
     head_commit_sha: str,
     base_commit_sha: str,
     runner_name: str,
+    max_wait_time: str,
 ):
     logger.debug(
         "Starting label analysis",
@@ -86,20 +98,8 @@ def label_analysis(
                 "Sorry. Codecov is having problems",
                 extra=dict(extra_log_attributes=dict(status_code=response.status_code)),
             )
-            if requested_labels:
-                logger.info(
-                    "Could not get set of tests to run. Falling back to running all collected tests."
-                )
-                fake_response = LabelAnalysisRequestResult(
-                    {
-                        "present_report_labels": [],
-                        "absent_labels": requested_labels,
-                        "present_diff_labels": [],
-                        "global_level_labels": [],
-                    }
-                )
-                return runner.process_labelanalysis_result(fake_response)
-            raise click.ClickException("Sorry. Codecov is having problems")
+            _fallback_to_collected_labels(requested_labels, runner)
+            return
         if response.status_code >= 400:
             logger.warning(
                 "Got a 4XX status code back from Codecov",
@@ -117,6 +117,7 @@ def label_analysis(
     eid = response.json()["external_id"]
     has_result = False
     logger.info("Label request sent. Waiting for result.")
+    start_wait = time.monotonic()
     time.sleep(2)
     while not has_result:
         resp_data = requests.get(
@@ -134,17 +135,36 @@ def label_analysis(
                 "Request had problems calculating",
                 extra=dict(extra_log_attributes=dict(resp_json=resp_json)),
             )
-            if requested_labels:
-                logger.info("Using requested labels as tests to run")
-                fake_response = LabelAnalysisRequestResult(
-                    {
-                        "present_report_labels": [],
-                        "absent_labels": requested_labels,
-                        "present_diff_labels": [],
-                        "global_level_labels": [],
-                    }
-                )
-                return runner.process_labelanalysis_result(fake_response)
+            _fallback_to_collected_labels(
+                collected_labels=requested_labels, runner=runner
+            )
+            return
+        if max_wait_time and (time.monotonic() - start_wait) > max_wait_time:
+            logger.error(
+                f"Exceeded max waiting time of {max_wait_time} seconds",
+            )
+            _fallback_to_collected_labels(
+                collected_labels=requested_labels, runner=runner
+            )
             return
         logger.info("Waiting more time for result")
         time.sleep(5)
+
+
+def _fallback_to_collected_labels(
+    collected_labels: List[str], runner: LabelAnalysisRunnerInterface
+) -> dict:
+    logger.info("Trying to fallback on collected labels")
+    if collected_labels:
+        logger.info("Using collected labels as tests to run")
+        fake_response = LabelAnalysisRequestResult(
+            {
+                "present_report_labels": [],
+                "absent_labels": collected_labels,
+                "present_diff_labels": [],
+                "global_level_labels": [],
+            }
+        )
+        return runner.process_labelanalysis_result(fake_response)
+    logger.error("Cannot fallback to collected labels because no labels were collected")
+    raise click.ClickException("Failed to get list of labels to run")

--- a/tests/commands/test_invoke_labelanalysis.py
+++ b/tests/commands/test_invoke_labelanalysis.py
@@ -1,17 +1,47 @@
-from unittest.mock import patch
-
 import pytest
 import responses
 from click.testing import CliRunner
 from responses import matchers
 
+from codecov_cli.commands.labelanalysis import _fallback_to_collected_labels
+from codecov_cli.commands.labelanalysis import time as labelanalysis_time
 from codecov_cli.main import cli
+from codecov_cli.runners.types import LabelAnalysisRequestResult
 from tests.factory import FakeProvider, FakeRunner, FakeVersioningSystem
 
 
 @pytest.fixture
 def fake_ci_provider():
     return FakeProvider()
+
+
+@pytest.fixture
+def get_labelanalysis_deps(mocker):
+    fake_ci_provider = FakeProvider()
+    fake_versioning_system = FakeVersioningSystem()
+    collected_labels = [
+        "test_present",
+        "test_absent",
+        "test_in_diff",
+        "test_global",
+    ]
+    fake_runner = FakeRunner(collect_tests_response=collected_labels)
+    fake_runner.process_labelanalysis_result = mocker.MagicMock()
+
+    mocker.patch.object(labelanalysis_time, "sleep")
+    mocker.patch("codecov_cli.main.get_ci_adapter", return_value=fake_ci_provider)
+    mocker.patch(
+        "codecov_cli.main.get_versioning_system",
+        return_value=fake_versioning_system,
+    )
+    mock_get_runner = mocker.patch(
+        "codecov_cli.commands.labelanalysis.get_runner", return_value=fake_runner
+    )
+    return {
+        "mock_get_runner": mock_get_runner,
+        "fake_runner": fake_runner,
+        "collected_labels": collected_labels,
+    }
 
 
 class TestLabelAnalysisCommand(object):
@@ -31,6 +61,9 @@ class TestLabelAnalysisCommand(object):
             "  --head-sha TEXT               Commit SHA (with 40 chars)  [required]",
             "  --base-sha TEXT               Commit SHA (with 40 chars)  [required]",
             "  --runner-name, --runner TEXT  Runner to use",
+            "  --max-wait-time INTEGER       Max time (in seconds) to wait for the label",
+            "                                analysis result before falling back to running",
+            "                                all tests. Default is to wait forever.",
             "  --help                        Show this message and exit.",
             "",
         ]
@@ -53,22 +86,10 @@ class TestLabelAnalysisCommand(object):
         assert result.exit_code != 0
         assert "Error: Missing option '--base-sha'." in result.output
 
-    def test_invoke_label_analysis(self, mocker):
-        fake_ci_provider = FakeProvider()
-        fake_versioning_system = FakeVersioningSystem()
-        fake_runner = FakeRunner(
-            collect_tests_response=[
-                "test_present",
-                "test_absent",
-                "test_in_diff",
-                "test_global",
-            ]
-        )
-        mocker.patch("codecov_cli.main.get_ci_adapter", return_value=fake_ci_provider)
-        mocker.patch(
-            "codecov_cli.main.get_versioning_system",
-            return_value=fake_versioning_system,
-        )
+    def test_invoke_label_analysis(self, get_labelanalysis_deps, mocker):
+        mock_get_runner = get_labelanalysis_deps["mock_get_runner"]
+        fake_runner = get_labelanalysis_deps["fake_runner"]
+        collected_labels = get_labelanalysis_deps["collected_labels"]
 
         label_analysis_result = {
             "present_report_labels": ["test_present"],
@@ -76,14 +97,6 @@ class TestLabelAnalysisCommand(object):
             "present_diff_labels": ["test_in_diff"],
             "global_level_labels": ["test_global"],
         }
-
-        def side_effect(result):
-            assert result == label_analysis_result
-
-        fake_runner.process_labelanalysis_result = side_effect
-        mock_get_runner = mocker.patch(
-            "codecov_cli.commands.labelanalysis.get_runner", return_value=fake_runner
-        )
 
         with responses.RequestsMock() as rsps:
             rsps.add(
@@ -107,5 +120,149 @@ class TestLabelAnalysisCommand(object):
                 obj={},
             )
             mock_get_runner.assert_called()
+            fake_runner.process_labelanalysis_result.assert_called_with(
+                label_analysis_result
+            )
             print(result.output)
         assert result.exit_code == 0
+
+    def test_fallback_to_collected_labels(self, mocker):
+        mock_runner = mocker.MagicMock()
+        collected_labels = ["label_1", "label_2", "label_3"]
+        fake_response = LabelAnalysisRequestResult(
+            {
+                "present_report_labels": [],
+                "absent_labels": collected_labels,
+                "present_diff_labels": [],
+                "global_level_labels": [],
+            }
+        )
+        _fallback_to_collected_labels(collected_labels, mock_runner)
+        mock_runner.process_labelanalysis_result.assert_called_with(fake_response)
+
+    def test_fallback_to_collected_labels_no_labels(self, mocker):
+        mock_runner = mocker.MagicMock()
+        with pytest.raises(Exception) as exp:
+            _fallback_to_collected_labels([], mock_runner)
+        mock_runner.process_labelanalysis_result.assert_not_called()
+        assert str(exp.value) == "Failed to get list of labels to run"
+
+    def test_fallback_collected_labels_covecov_500_error(
+        self, get_labelanalysis_deps, mocker
+    ):
+        mock_get_runner = get_labelanalysis_deps["mock_get_runner"]
+        fake_runner = get_labelanalysis_deps["fake_runner"]
+        collected_labels = get_labelanalysis_deps["collected_labels"]
+        with responses.RequestsMock() as rsps:
+            rsps.add(
+                responses.POST,
+                "https://api.codecov.io/labels/labels-analysis",
+                status=500,
+                match=[
+                    matchers.header_matcher({"Authorization": "Repotoken STATIC_TOKEN"})
+                ],
+            )
+            cli_runner = CliRunner()
+            result = cli_runner.invoke(
+                cli,
+                ["-v", "label-analysis", "--token=STATIC_TOKEN", "--base-sha=BASE_SHA"],
+                obj={},
+            )
+            mock_get_runner.assert_called()
+            fake_runner.process_labelanalysis_result.assert_called_with(
+                {
+                    "present_report_labels": [],
+                    "absent_labels": collected_labels,
+                    "present_diff_labels": [],
+                    "global_level_labels": [],
+                }
+            )
+            print(result.output)
+        assert result.exit_code == 0
+
+    def test_fallback_collected_labels_codecov_error_processing_label_analysis(
+        self, get_labelanalysis_deps, mocker
+    ):
+        mock_get_runner = get_labelanalysis_deps["mock_get_runner"]
+        fake_runner = get_labelanalysis_deps["fake_runner"]
+        collected_labels = get_labelanalysis_deps["collected_labels"]
+
+        with responses.RequestsMock() as rsps:
+            rsps.add(
+                responses.POST,
+                "https://api.codecov.io/labels/labels-analysis",
+                json={"external_id": "label-analysis-request-id"},
+                status=201,
+                match=[
+                    matchers.header_matcher({"Authorization": "Repotoken STATIC_TOKEN"})
+                ],
+            )
+            rsps.add(
+                responses.GET,
+                "https://api.codecov.io/labels/labels-analysis/label-analysis-request-id",
+                json={"state": "error"},
+            )
+            cli_runner = CliRunner()
+            result = cli_runner.invoke(
+                cli,
+                ["-v", "label-analysis", "--token=STATIC_TOKEN", "--base-sha=BASE_SHA"],
+                obj={},
+            )
+            mock_get_runner.assert_called()
+            fake_runner.process_labelanalysis_result.assert_called_with(
+                {
+                    "present_report_labels": [],
+                    "absent_labels": collected_labels,
+                    "present_diff_labels": [],
+                    "global_level_labels": [],
+                }
+            )
+            print(result.output)
+        assert result.exit_code == 0
+
+    def test_fallback_collected_labels_codecov_max_wait_time_exceeded(
+        self, get_labelanalysis_deps, mocker
+    ):
+        mock_get_runner = get_labelanalysis_deps["mock_get_runner"]
+        fake_runner = get_labelanalysis_deps["fake_runner"]
+        collected_labels = get_labelanalysis_deps["collected_labels"]
+        mocker.patch.object(labelanalysis_time, "monotonic", side_effect=[0, 6])
+
+        with responses.RequestsMock() as rsps:
+            rsps.add(
+                responses.POST,
+                "https://api.codecov.io/labels/labels-analysis",
+                json={"external_id": "label-analysis-request-id"},
+                status=201,
+                match=[
+                    matchers.header_matcher({"Authorization": "Repotoken STATIC_TOKEN"})
+                ],
+            )
+            rsps.add(
+                responses.GET,
+                "https://api.codecov.io/labels/labels-analysis/label-analysis-request-id",
+                json={"state": "processing"},
+            )
+            cli_runner = CliRunner()
+            result = cli_runner.invoke(
+                cli,
+                [
+                    "-v",
+                    "label-analysis",
+                    "--token=STATIC_TOKEN",
+                    "--base-sha=BASE_SHA",
+                    "--max-wait-time=5",
+                ],
+                obj={},
+            )
+            print(result)
+            assert result.exit_code == 0
+        mock_get_runner.assert_called()
+        fake_runner.process_labelanalysis_result.assert_called_with(
+            {
+                "present_report_labels": [],
+                "absent_labels": collected_labels,
+                "present_diff_labels": [],
+                "global_level_labels": [],
+            }
+        )


### PR DESCRIPTION
This option allows customers to decide how long they want to way for the label analysis result
(e.g. the set of labels to run) before falling back to running the entire test suite.

I'm adding this option because on one occasion I've seen it taking more than 40min to get a response.
No doubt some processing error happened and it failed silently, or something like that, and the user's
CI just waited until it too was killed (for taking too long).

One brute force solution is to just have a configurable time limit.
Also taking this opportunity to refactor a little bit label analysis and improve coverage.