### PR TITLE
fix: send post data as json

### DIFF
--- a/codecov_cli/helpers/request.py
+++ b/codecov_cli/helpers/request.py
@@ -1,3 +1,4 @@
+import json
 import logging
 import uuid
 
@@ -13,11 +14,14 @@ def send_post_request(
     data: dict = None,
     headers: dict = None,
 ):
+    headers['Content-Type'] = 'application/json'
+
     resp = requests.post(
         url=url,
-        data=data,
+        data=json.dumps(data),
         headers=headers,
     )
+
     return request_result(resp)
 
 

--- a/codecov_cli/helpers/request.py
+++ b/codecov_cli/helpers/request.py
@@ -14,11 +14,9 @@ def send_post_request(
     data: dict = None,
     headers: dict = None,
 ):
-    headers['Content-Type'] = 'application/json'
-
     resp = requests.post(
         url=url,
-        data=json.dumps(data),
+        data=data,
         headers=headers,
     )
 

--- a/codecov_cli/helpers/request.py
+++ b/codecov_cli/helpers/request.py
@@ -1,4 +1,3 @@
-import json
 import logging
 import uuid
 
@@ -16,7 +15,7 @@ def send_post_request(
 ):
     resp = requests.post(
         url=url,
-        data=data,
+        json=data,
         headers=headers,
     )
 

--- a/tests/data/reports_examples.py
+++ b/tests/data/reports_examples.py
@@ -1,4 +1,4 @@
-"""This module defiens some reports examples that are going to be used by tests"""
+"""This module defines some reports examples that are going to be used by tests"""
 
 # Avoid parsing and removing indentation from multiline strings by defining them in the top level of this file
 

--- a/tests/helpers/test_upload_sender.py
+++ b/tests/helpers/test_upload_sender.py
@@ -31,6 +31,7 @@ named_upload_data = {
 }
 request_data = {
     "ci_url": "build_url",
+    "env": {},
     "flags": "flags",
     "job_code": "job_code",
     "name": "name",
@@ -131,7 +132,7 @@ class TestUploadSender(object):
         headers = {"Authorization": f"token {random_token.hex}"}
 
         mocked_legacy_upload_endpoint.match = [
-            matchers.urlencoded_params_matcher(request_data),
+            matchers.json_params_matcher(request_data),
             matchers.header_matcher(headers),
         ]
 


### PR DESCRIPTION
When running locally, we get a response back from server that `Content-Length` is not set. This is seen to be true, that `requests` does not automatically add a `Content-Length` header. 

However, sending the `post` data as `json` seems to solve this case.