### PR TITLE
Patch import errors (the return of subprocess.run)

### DIFF
--- a/codecov_cli/runners/python_standard_runner.py
+++ b/codecov_cli/runners/python_standard_runner.py
@@ -1,9 +1,12 @@
 import logging
 import random
+import subprocess
 from contextlib import redirect_stdout
 from io import StringIO, TextIOWrapper
-from multiprocessing import Queue, get_context
+from multiprocessing import Process, Queue, get_context
 from os import getcwd
+from queue import Empty
+from subprocess import CalledProcessError
 from sys import path, stdout
 from typing import List, Optional
 
@@ -23,8 +26,19 @@ class PythonStandardRunnerConfigParams(dict):
         return self.get("collect_tests_options", [])
 
     @property
+    def strict_mode(self) -> bool:
+        """
+        Run pytest from within Python instead of using subprocess.run
+        This is potentailly safer than using subprocess.run because it guarantees better that
+        the program running is indeed pytest.
+        But it might not work everytime due to import issues related to Python caching modules.
+        """
+        return self.get("strict_mode", False)
+
+    @property
     def include_curr_dir(self) -> bool:
-        """ "
+        """
+        Only valid for 'strict mode'
         Account for the difference 'pytest' vs 'python -m pytest'
         https://docs.pytest.org/en/7.1.x/how-to/usage.html#calling-pytest-through-python-m-pytest
         """
@@ -32,6 +46,11 @@ class PythonStandardRunnerConfigParams(dict):
 
 
 def _include_curr_dir(method):
+    """
+    Account for the difference 'pytest' vs 'python -m pytest'
+    https://docs.pytest.org/en/7.1.x/how-to/usage.html#calling-pytest-through-python-m-pytest
+    """
+
     def call_method(self, *args, **kwargs):
         include_curr_dir = self.params.include_curr_dir
         curr_dir = getcwd()
@@ -64,8 +83,8 @@ def _execute_pytest_subprocess(
     with redirect_stdout(subproces_stdout):
         result = pytest.main(pytest_args)
     if capture_output:
-        queue.put(subproces_stdout.getvalue())
-    queue.put(result)
+        queue.put({"output": subproces_stdout.getvalue()})
+    queue.put({"result": result})
 
 
 class PythonStandardRunner(LabelAnalysisRunnerInterface):
@@ -75,26 +94,40 @@ class PythonStandardRunner(LabelAnalysisRunnerInterface):
             config_params = {}
         self.params = PythonStandardRunnerConfigParams(config_params)
 
+    def _wait_pytest(self, pytest_process: Process, queue: Queue):
+        pytest_process.start()
+        result = None
+        output = None
+        while pytest_process.exitcode == 0 or pytest_process.exitcode == None:
+            from_queue = None
+            try:
+                from_queue = queue.get(timeout=1)
+            except Empty:
+                pass
+            if from_queue and "output" in from_queue:
+                output = from_queue["output"]
+            if from_queue and "result" in from_queue:
+                result = from_queue["result"]
+            if result is not None:
+                break
+        pytest_process.join()
+        return result, output
+
     @_include_curr_dir
-    def _execute_pytest(
-        self, pytest_args: List[str], capture_output: bool = True, numprocess: int = 1
+    def _execute_pytest_strict(
+        self, pytest_args: List[str], capture_output: bool = True
     ) -> str:
         """Handles calling pytest from Python in a subprocess.
         Raises Exception if pytest fails
         Returns the complete pytest output
         """
-        ctx = get_context("fork")
-        output = None
+        ctx = get_context(method="fork")
         queue = ctx.Queue(2)
         p = ctx.Process(
             target=_execute_pytest_subprocess,
             args=[pytest_args, queue, stdout, capture_output],
         )
-        p.start()
-        if capture_output:
-            output = queue.get()  # Output from pytest emitted by subprocess
-        result = queue.get()  # Pytest exit code emitted by subprocess
-        p.join()
+        result, output = self._wait_pytest(p, queue)
 
         if p.exitcode != 0 or (result != pytest.ExitCode.OK and result != 0):
             logger.error(
@@ -103,6 +136,29 @@ class PythonStandardRunner(LabelAnalysisRunnerInterface):
             )
             raise Exception("Pytest did not run correctly")
         return output
+
+    def _execute_pytest(self, pytest_args: List[str], capture_output: bool = True):
+        """Handles calling pytest using subprocess.run.
+        Raises Exception if pytest fails
+        Returns the complete pytest output
+        """
+        command = ["python", "-m", "pytest"] + pytest_args
+        try:
+            result = subprocess.run(
+                command,
+                capture_output=capture_output,
+                check=True,
+                stdout=(stdout if not capture_output else None),
+            )
+        except CalledProcessError as exp:
+            logger.error(exp.stderr)
+            logger.error(
+                "Pytest did not run correctly",
+                extra=dict(extra_log_attributes=dict(exit_code=exp.returncode)),
+            )
+            raise Exception("Pytest did not run correctly")
+        if capture_output:
+            return result.stdout.decode()
 
     def collect_tests(self):
         default_options = ["-q", "--collect-only"]
@@ -115,7 +171,10 @@ class PythonStandardRunner(LabelAnalysisRunnerInterface):
             ),
         )
 
-        output = self._execute_pytest(options_to_use)
+        if self.params.strict_mode:
+            output = self._execute_pytest_strict(options_to_use)
+        else:
+            output = self._execute_pytest(options_to_use)
         lines = output.split(sep="\n")
         test_names = list(line for line in lines if ("::" in line and "test" in line))
         return test_names
@@ -161,6 +220,9 @@ class PythonStandardRunner(LabelAnalysisRunnerInterface):
             "Pytest command",
             extra=dict(extra_log_attributes=dict(command_array=command_array)),
         )
-        output = self._execute_pytest(command_array, capture_output=False)
+        if self.params.strict_mode:
+            output = self._execute_pytest_strict(command_array, capture_output=False)
+        else:
+            output = self._execute_pytest(command_array, capture_output=False)
         logger.info("Finished running tests successfully")
         logger.debug(output)

--- a/tests/runners/test_python_standard_runner.py
+++ b/tests/runners/test_python_standard_runner.py
@@ -1,3 +1,4 @@
+from subprocess import CalledProcessError
 from typing import List
 from unittest.mock import MagicMock, call, patch
 
@@ -23,7 +24,9 @@ def test_execute_pytest_subprocess(mock_pytest, mocker):
     _execute_pytest_subprocess(["pytest", "args"], mock_queue, MagicMock())
     mock_pytest.main.assert_called_with(["pytest", "args"])
     assert mock_queue.put.call_count == 2
-    mock_queue.put.assert_has_calls([call("Pytest output\n"), call(ExitCode.OK)])
+    mock_queue.put.assert_has_calls(
+        [call({"output": "Pytest output\n"}), call({"result": ExitCode.OK})]
+    )
 
 
 @patch("codecov_cli.runners.python_standard_runner.pytest")
@@ -37,7 +40,7 @@ def test_execute_pytest_subprocess_no_capture_stdout(mock_pytest, mocker):
     _execute_pytest_subprocess(["pytest", "args"], mock_queue, MagicMock(), False)
     mock_pytest.main.assert_called_with(["pytest", "args"])
     assert mock_queue.put.call_count == 1
-    mock_queue.put.assert_has_calls([call(ExitCode.OK)])
+    mock_queue.put.assert_has_calls([call({"result": ExitCode.OK})])
 
 
 class TestPythonStandardRunner(object):
@@ -54,22 +57,39 @@ class TestPythonStandardRunner(object):
         runner_with_params = PythonStandardRunner(config_params)
         assert runner_with_params.params == config_params
 
+    @patch("codecov_cli.runners.python_standard_runner.subprocess")
+    def test_execute_pytest(self, mock_subprocess):
+        output = "Output in stdout"
+        return_value = MagicMock(stdout=output.encode("utf-8"))
+        mock_subprocess.run.return_value = return_value
+
+        result = self.runner._execute_pytest(["--option", "--ignore=batata"])
+        mock_subprocess.run.assert_called_with(
+            ["python", "-m", "pytest", "--option", "--ignore=batata"],
+            capture_output=True,
+            check=True,
+            stdout=None,
+        )
+        assert result == output
+
     @patch(
         "codecov_cli.runners.python_standard_runner.getcwd",
         return_value="current directory",
     )
     @patch("codecov_cli.runners.python_standard_runner.path")
     @patch("codecov_cli.runners.python_standard_runner.get_context")
-    def test_execute_pytest(self, mock_get_context, mock_sys_path, mock_getcwd):
+    def test_execute_pytest_strict_mode(
+        self, mock_get_context, mock_sys_path, mock_getcwd
+    ):
         output = "Output in stdout"
         mock_queue = MagicMock()
-        mock_queue.get.side_effect = [output, ExitCode.OK]
+        mock_queue.get.side_effect = [{"output": output}, {"result": ExitCode.OK}]
         mock_process = MagicMock()
         mock_process.exitcode = 0
         mock_get_context.return_value.Queue.return_value = mock_queue
         mock_get_context.return_value.Process.return_value = mock_process
 
-        result = self.runner._execute_pytest(["--option", "--ignore=batata"])
+        result = self.runner._execute_pytest_strict(["--option", "--ignore=batata"])
         mock_get_context.return_value.Queue.assert_called_with(2)
         mock_get_context.return_value.Process.assert_called_with(
             target=_execute_pytest_subprocess,
@@ -86,17 +106,22 @@ class TestPythonStandardRunner(object):
     )
     @patch("codecov_cli.runners.python_standard_runner.path")
     @patch("codecov_cli.runners.python_standard_runner.get_context")
-    def test_execute_pytest_fail(self, mock_get_context, mock_sys_path, mock_getcwd):
+    def test_execute_pytest_fail_strict_mode(
+        self, mock_get_context, mock_sys_path, mock_getcwd
+    ):
         output = "Output in stdout"
         mock_queue = MagicMock()
-        mock_queue.get.side_effect = [output, ExitCode.INTERNAL_ERROR]
+        mock_queue.get.side_effect = [
+            {"output": output},
+            {"result": ExitCode.INTERNAL_ERROR},
+        ]
         mock_process = MagicMock()
         mock_process.exitcode = 0
         mock_get_context.return_value.Queue.return_value = mock_queue
         mock_get_context.return_value.Process.return_value = mock_process
 
         with pytest.raises(Exception) as exp:
-            _ = self.runner._execute_pytest(["--option", "--ignore=batata"])
+            _ = self.runner._execute_pytest_strict(["--option", "--ignore=batata"])
         assert str(exp.value) == "Pytest did not run correctly"
         mock_get_context.return_value.Queue.assert_called_with(2)
         mock_get_context.return_value.Process.assert_called_with(
@@ -105,15 +130,28 @@ class TestPythonStandardRunner(object):
         )
         mock_sys_path.append.assert_called_with("current directory")
 
+    @patch("codecov_cli.runners.python_standard_runner.subprocess")
+    def test_execute_pytest_fail(self, mock_subprocess):
+        def side_effect(command, *args, **kwargs):
+            raise CalledProcessError(
+                cmd=command, returncode=2, stderr="Some error occured"
+            )
+
+        mock_subprocess.run.side_effect = side_effect
+
+        with pytest.raises(Exception) as exp:
+            _ = self.runner._execute_pytest(["--option", "--ignore=batata"])
+        assert str(exp.value) == "Pytest did not run correctly"
+
     @patch("codecov_cli.runners.python_standard_runner.getcwd")
     @patch("codecov_cli.runners.python_standard_runner.path")
     @patch("codecov_cli.runners.python_standard_runner.get_context")
-    def test_execute_pytest_NOT_include_curr_dir(
+    def test_execute_pytest_strict_NOT_include_curr_dir(
         self, mock_get_context, mock_sys_path, mock_getcwd
     ):
         output = "Output in stdout"
         mock_queue = MagicMock()
-        mock_queue.get.side_effect = [output, ExitCode.OK]
+        mock_queue.get.side_effect = [{"output": output}, {"result": ExitCode.OK}]
         mock_process = MagicMock()
         mock_process.exitcode = 0
         mock_get_context.return_value.Queue.return_value = mock_queue
@@ -121,7 +159,7 @@ class TestPythonStandardRunner(object):
 
         config_params = dict(include_curr_dir=False)
         runner = PythonStandardRunner(config_params=config_params)
-        result = runner._execute_pytest(["--option", "--ignore=batata"])
+        result = runner._execute_pytest_strict(["--option", "--ignore=batata"])
         mock_get_context.return_value.Queue.assert_called_with(2)
         mock_get_context.return_value.Process.assert_called_with(
             target=_execute_pytest_subprocess,
@@ -145,9 +183,40 @@ class TestPythonStandardRunner(object):
             "_execute_pytest",
             return_value="\n".join(collected_test_list),
         )
+        mock_execute_strict = mocker.patch.object(
+            PythonStandardRunner,
+            "_execute_pytest_strict",
+            return_value="\n".join(collected_test_list),
+        )
 
         collected_tests_from_runner = self.runner.collect_tests()
         mock_execute.assert_called_with(["-q", "--collect-only"])
+        mock_execute_strict.assert_not_called()
+        assert collected_tests_from_runner == collected_test_list
+
+    def test_collect_tests_strict(self, mocker):
+        collected_test_list = [
+            "tests/services/upload/test_upload_service.py::test_do_upload_logic_happy_path_legacy_uploader"
+            "tests/services/upload/test_upload_service.py::test_do_upload_logic_happy_path"
+            "tests/services/upload/test_upload_service.py::test_do_upload_logic_dry_run"
+            "tests/services/upload/test_upload_service.py::test_do_upload_logic_verbose"
+        ]
+        mock_execute = mocker.patch.object(
+            PythonStandardRunner,
+            "_execute_pytest",
+            return_value="\n".join(collected_test_list),
+        )
+        mock_execute_strict = mocker.patch.object(
+            PythonStandardRunner,
+            "_execute_pytest_strict",
+            return_value="\n".join(collected_test_list),
+        )
+
+        runner_config = {"strict_mode": True}
+        runner = PythonStandardRunner(runner_config)
+        collected_tests_from_runner = runner.collect_tests()
+        mock_execute_strict.assert_called_with(["-q", "--collect-only"])
+        mock_execute.assert_not_called()
         assert collected_tests_from_runner == collected_test_list
 
     def test_collect_tests_with_options(self, mocker):
@@ -181,6 +250,36 @@ class TestPythonStandardRunner(object):
 
         self.runner.process_labelanalysis_result(label_analysis_result)
         args, kwargs = mock_execute.call_args
+        assert kwargs == {"capture_output": False}
+        assert isinstance(args[0], list)
+        actual_command = args[0]
+        assert actual_command[:2] == [
+            "--cov=./",
+            "--cov-context=test",
+        ]
+        assert sorted(actual_command[2:]) == [
+            "test_absent",
+            "test_global",
+            "test_in_diff",
+        ]
+
+    def test_process_label_analysis_result_strict(self, mocker):
+        label_analysis_result = {
+            "present_report_labels": ["test_present"],
+            "absent_labels": ["test_absent"],
+            "present_diff_labels": ["test_in_diff"],
+            "global_level_labels": ["test_global"],
+        }
+        mock_execute = mocker.patch.object(PythonStandardRunner, "_execute_pytest")
+        mock_execute_strict = mocker.patch.object(
+            PythonStandardRunner, "_execute_pytest_strict"
+        )
+
+        runner_config = {"strict_mode": True}
+        runner = PythonStandardRunner(runner_config)
+        runner.process_labelanalysis_result(label_analysis_result)
+        mock_execute.assert_not_called()
+        args, kwargs = mock_execute_strict.call_args
         assert kwargs == {"capture_output": False}
         assert isinstance(args[0], list)
         actual_command = args[0]


### PR DESCRIPTION
Previously (around commit 8c5b289c90a6be8f53eb13babb2a19ef24e1b6ab) we had removed `subprocess.run` from the `PythonStandardRunner` to make it extra safe. Instead the default way of using it was calling `pytest` directly from Python.

The thing is that Python import process when running pytest from Python can get messy. Because imported modules are cached. Out of the blue we started seeing "pytest.PytestAssertRewriteWarning" errors. The most likely cause is that some modules are imported by the CLI, and when the process that runs Pytest is created it inherits some of the parent's process resources ([because it's forked](https://docs.python.org/3/library/multiprocessing.html#contexts-and-start-methods)). Yes I tried with "spawn" instead of "fork" but that didn't work either /:

However `subprocess.run` (which probably works differently under the hood?) does work. It's better to have something slightly more dangerous but that is more reliable in working, than continue to try and make the safer option work (which (1) is starting to feel hacky and (2) I am out of ideas and we want to ship this feature rather soon). So the logical choice is to make `subprocess.run` the default way of running pytest. It's also way simpler.

Nevertheless, in the process of trying to make the (now called) strict option work I made some improvement to it in terms of failing when the subprocess fails. Before it was gettign stuck trying to read from the queue. Now it fails right away.

Ans yes, instead of just throwing away the previous approach we're now calling it "strict mode".