### PR TITLE
add -h for help

### DIFF
--- a/codecov_cli/main.py
+++ b/codecov_cli/main.py
@@ -47,6 +47,7 @@ def cli(
     verbose: bool = False,
 ):
     configure_logger(logger, log_level=(logging.DEBUG if verbose else logging.INFO))
+    ctx.help_option_names = ["-h", "--help"]
     ctx.obj["ci_adapter"] = get_ci_adapter(auto_load_params_from)
     ctx.obj["versioning_system"] = get_versioning_system()
     ctx.obj["codecov_yaml"] = (

--- a/tests/commands/test_invoke_labelanalysis.py
+++ b/tests/commands/test_invoke_labelanalysis.py
@@ -64,7 +64,7 @@ class TestLabelAnalysisCommand(object):
             "  --max-wait-time INTEGER       Max time (in seconds) to wait for the label",
             "                                analysis result before falling back to running",
             "                                all tests. Default is to wait forever.",
-            "  --help                        Show this message and exit.",
+            "  -h, --help                    Show this message and exit.",
             "",
         ]
 


### PR DESCRIPTION
now we can use `codecovcli {command} -h ` or `codecovcli {command} --help `