### PR TITLE
log destination url for user when uploading

### DIFF
--- a/codecov_cli/services/upload/upload_sender.py
+++ b/codecov_cli/services/upload/upload_sender.py
@@ -64,6 +64,10 @@ class UploadSender(object):
         if resp_from_codecov.status_code >= 400:
             return resp_from_codecov
         resp_json_obj = json.loads(resp_from_codecov.text)
+        if resp_json_obj.get("url"):
+            logger.info(
+                f"Your upload is now processing. When finished, results will be available at: {resp_json_obj.get('url')}"
+            )
         logger.debug(
             "Upload request to Codecov complete.",
             extra=dict(extra_log_attributes=dict(response=resp_json_obj)),

--- a/tests/helpers/test_upload_sender.py
+++ b/tests/helpers/test_upload_sender.py
@@ -51,7 +51,10 @@ def mocked_legacy_upload_endpoint(mocked_responses):
         responses.POST,
         f"https://api.codecov.io/upload/github/{encoded_slug}/commits/{random_sha}/reports/{named_upload_data['report_code']}/uploads",
         status=200,
-        json={"raw_upload_location": "https://puturl.com"},
+        json={
+            "raw_upload_location": "https://puturl.com",
+            "url": "https://app.codecov.io/commit-url",
+        },
     )
     mocked_responses.add(resp)
     yield resp
@@ -146,6 +149,8 @@ class TestUploadSender(object):
 
         post_req_made = mocked_responses.calls[0].request
         encoded_slug = encode_slug(named_upload_data["slug"])
+        response = json.loads(mocked_responses.calls[0].response.text)
+        assert response.get("url") == "https://app.codecov.io/commit-url"
         assert (
             post_req_made.url
             == f"https://api.codecov.io/upload/github/{encoded_slug}/commits/{random_sha}/reports/{named_upload_data['report_code']}/uploads"


### PR DESCRIPTION
Show a commit url or UI url to the user after uploading so it can take him directly to the codecov-app