### PR TITLE
Fix custom plugin system config fields 

### DIFF
--- a/codecov_cli/plugins/__init__.py
+++ b/codecov_cli/plugins/__init__.py
@@ -45,10 +45,13 @@ def _load_plugin_from_yaml(plugin_dict: typing.Dict):
         )
         return NoopPlugin()
     try:
-        return class_obj(**plugin_dict["params"])
+        if "params" not in plugin_dict or plugin_dict["params"] is None:
+            return class_obj()
+        else:
+            return class_obj(**plugin_dict["params"])
     except TypeError:
         click.secho(
-            f"Unable to instantiate {class_obj} with parameters {plugin_dict['params']}",
+            f"Unable to instantiate {class_obj} with provided parameters { plugin_dict.get('params', '') }",
             err=True,
         )
         return NoopPlugin()

--- a/codecov_cli/plugins/__init__.py
+++ b/codecov_cli/plugins/__init__.py
@@ -50,7 +50,7 @@ def _load_plugin_from_yaml(plugin_dict: typing.Dict):
             return class_obj(**plugin_dict["params"])
         else:
             return class_obj()
-        
+
     except TypeError:
         click.secho(
             f"Unable to instantiate {class_obj} with provided parameters { plugin_dict.get('params', '') }",

--- a/codecov_cli/plugins/__init__.py
+++ b/codecov_cli/plugins/__init__.py
@@ -30,10 +30,17 @@ def select_preparation_plugins(cli_config: typing.Dict, plugin_names: typing.Lis
 
 def _load_plugin_from_yaml(plugin_dict: typing.Dict):
     try:
-        class_obj = import_module(plugin_dict["path"])
+        module_obj = import_module(plugin_dict["module"])
+        class_obj = getattr(module_obj, plugin_dict["class"])
     except ModuleNotFoundError:
         click.secho(
-            f"Unable to dynamically load plugin on path {plugin_dict['path']}",
+            f"Unable to dynamically load module {plugin_dict['module']}",
+            err=True,
+        )
+        return NoopPlugin()
+    except AttributeError:
+        click.secho(
+            f"Unable to dynamically load class {plugin_dict['class']} from module {plugin_dict['module']}",
             err=True,
         )
         return NoopPlugin()

--- a/codecov_cli/plugins/__init__.py
+++ b/codecov_cli/plugins/__init__.py
@@ -45,10 +45,12 @@ def _load_plugin_from_yaml(plugin_dict: typing.Dict):
         )
         return NoopPlugin()
     try:
-        if "params" not in plugin_dict or plugin_dict["params"] is None:
-            return class_obj()
-        else:
+        params = plugin_dict.get("params", None)
+        if params:
             return class_obj(**plugin_dict["params"])
+        else:
+            return class_obj()
+        
     except TypeError:
         click.secho(
             f"Unable to instantiate {class_obj} with provided parameters { plugin_dict.get('params', '') }",

--- a/tests/plugins/test_instantiation.py
+++ b/tests/plugins/test_instantiation.py
@@ -11,35 +11,51 @@ from codecov_cli.plugins.pycoverage import Pycoverage, PycoverageConfig
 
 
 def test_load_plugin_from_yaml(mocker):
-    class SamplePlugin(object):
-        def __init__(self, banana, other):
-            self.something = banana
-            self.other = other
+    class SampleModule(object):
+        class SamplePlugin(object):
+            def __init__(self, banana, other):
+                self.something = banana
+                self.other = other
 
-    mocker.patch("codecov_cli.plugins.import_module", return_value=SamplePlugin)
+    mocker.patch("codecov_cli.plugins.import_module", return_value=SampleModule)
     res = _load_plugin_from_yaml(
-        {"path": "a", "params": {"banana": "super", "other": 1}}
+        {"module": "a", "class": "SamplePlugin",  "params": {"banana": "super", "other": 1}}
     )
-    assert isinstance(res, SamplePlugin)
+    assert isinstance(res, SampleModule.SamplePlugin)
     assert res.something == "super"
     assert res.other == 1
 
 
 def test_load_plugin_from_yaml_non_existing_class(mocker):
+    class SampleModule(object):
+        class SamplePlugin(object):
+            def __init__(self, banana, other):
+                self.something = banana
+                self.other = other
+
+    mocker.patch("codecov_cli.plugins.import_module", return_value=SampleModule)
+    
     res = _load_plugin_from_yaml(
-        {"path": "nonexisting.path", "params": {"banana": "super", "other": 1}}
+        {"module": "a", "class": "NonExistingClass", "params": {"banana": "super", "other": 1}}
+    )
+    assert isinstance(res, NoopPlugin)
+
+def test_load_plugin_from_yaml_non_existing_module(mocker):
+    res = _load_plugin_from_yaml(
+        {"module": "nonexisting.module", "class": "nonexisting.class", "params": {"banana": "super", "other": 1}}
     )
     assert isinstance(res, NoopPlugin)
 
 
 def test_load_plugin_from_yaml_bad_parameters(mocker):
-    class SamplePlugin(object):
-        def __init__(self, banana):
-            pass
+    class SampleModule(object):
+        class SamplePlugin(object):
+            def __init__(self, banana):
+                pass
 
-    mocker.patch("codecov_cli.plugins.import_module", return_value=SamplePlugin)
+    mocker.patch("codecov_cli.plugins.import_module", return_value=SampleModule)
     res = _load_plugin_from_yaml(
-        {"path": "a", "params": {"banana": "super", "other": 1}}
+        {"module": "a", "class": "SamplePlugin", "params": {"banana": "super", "other": 1}}
     )
     assert isinstance(res, NoopPlugin)
 
@@ -80,27 +96,31 @@ def test_get_plugin_compress_pycoverage():
 
 
 def test_select_preparation_plugins(mocker):
-    class SamplePlugin(object):
-        def __init__(self, banana=None):
-            pass
+    class SampleModule(object):
+        class SamplePlugin(object):
+            def __init__(self, banana=None):
+                pass
 
-    class SecondSamplePlugin(object):
-        def __init__(self, banana=None):
-            pass
+    class SecondSampleModule(object):
+        class SecondSamplePlugin(object):
+            def __init__(self, banana=None):
+                pass
 
     mocker.patch(
         "codecov_cli.plugins.import_module",
-        side_effect=[ModuleNotFoundError, SamplePlugin, SecondSamplePlugin],
+        side_effect=[ModuleNotFoundError, SampleModule, SecondSampleModule],
     )
+
     res = select_preparation_plugins(
         {
             "plugins": {
                 "otherthing": {
-                    "path": "a",
+                    "module": "a",
+                    "class": "SamplePlugin",
                     "params": {"banana": "apple", "pineapple": 2},
                 },
-                "second": {"path": "b", "params": {"banana": "apple"}},
-                "something": {"path": "c"},
+                "second": {"module": "c", "class": "SecondSamplePlugin", "params": {"banana": "apple"}},
+                "something": {"module": "e", "class": "f"},
             }
         },
         ["gcov", "something", "otherthing", "second", "lalalala"],
@@ -109,5 +129,5 @@ def test_select_preparation_plugins(mocker):
     assert isinstance(res[0], GcovPlugin)
     assert isinstance(res[1], NoopPlugin)
     assert isinstance(res[2], NoopPlugin)
-    assert isinstance(res[3], SecondSamplePlugin)
+    assert isinstance(res[3], SecondSampleModule.SecondSamplePlugin)
     assert isinstance(res[4], NoopPlugin)

--- a/tests/plugins/test_instantiation.py
+++ b/tests/plugins/test_instantiation.py
@@ -59,6 +59,29 @@ def test_load_plugin_from_yaml_bad_parameters(mocker):
     )
     assert isinstance(res, NoopPlugin)
 
+def test_load_plugin_from_yaml_missing_params(mocker):
+    class SampleModule(object):
+        class SamplePlugin(object):
+            def __init__(self):
+                pass
+
+    mocker.patch("codecov_cli.plugins.import_module", return_value=SampleModule)
+    res = _load_plugin_from_yaml(
+        {"module": "a", "class": "SamplePlugin"}
+    )
+    assert isinstance(res, SampleModule.SamplePlugin)
+
+def test_load_plugin_from_yaml_empty_params(mocker):
+    class SampleModule(object):
+        class SamplePlugin(object):
+            def __init__(self):
+                pass
+
+    mocker.patch("codecov_cli.plugins.import_module", return_value=SampleModule)
+    res = _load_plugin_from_yaml(
+        {"module": "a", "class": "SamplePlugin", "params" : {}}
+    )
+    assert isinstance(res, SampleModule.SamplePlugin)
 
 def test_get_plugin_gcov():
     res = _get_plugin({}, "gcov")

--- a/tests/plugins/test_instantiation.py
+++ b/tests/plugins/test_instantiation.py
@@ -11,27 +11,30 @@ from codecov_cli.plugins.pycoverage import Pycoverage, PycoverageConfig
 
 
 def test_load_plugin_from_yaml(mocker):
-    class SampleModule(object):
-        class SamplePlugin(object):
-            def __init__(self, banana, other):
-                self.something = banana
-                self.other = other
+    class SamplePlugin(object):
+        def __init__(self, banana, other):
+            self.something = banana
+            self.other = other
+    
+    SampleModule = mocker.MagicMock(SamplePlugin=SamplePlugin)
 
     mocker.patch("codecov_cli.plugins.import_module", return_value=SampleModule)
     res = _load_plugin_from_yaml(
         {"module": "a", "class": "SamplePlugin",  "params": {"banana": "super", "other": 1}}
     )
-    assert isinstance(res, SampleModule.SamplePlugin)
+    assert isinstance(res, SamplePlugin)
     assert res.something == "super"
     assert res.other == 1
 
 
 def test_load_plugin_from_yaml_non_existing_class(mocker):
-    class SampleModule(object):
-        class SamplePlugin(object):
-            def __init__(self, banana, other):
-                self.something = banana
-                self.other = other
+    class SamplePlugin(object):
+        def __init__(self, banana, other):
+            self.something = banana
+            self.other = other
+    
+    SampleModule = mocker.MagicMock(SamplePlugin=SamplePlugin)
+    del SampleModule.NonExistingClass
 
     mocker.patch("codecov_cli.plugins.import_module", return_value=SampleModule)
     
@@ -48,10 +51,12 @@ def test_load_plugin_from_yaml_non_existing_module(mocker):
 
 
 def test_load_plugin_from_yaml_bad_parameters(mocker):
-    class SampleModule(object):
-        class SamplePlugin(object):
-            def __init__(self, banana):
-                pass
+    class SamplePlugin(object):
+        def __init__(self, banana):
+            pass
+    
+    SampleModule = mocker.MagicMock(SamplePlugin=SamplePlugin)
+
 
     mocker.patch("codecov_cli.plugins.import_module", return_value=SampleModule)
     res = _load_plugin_from_yaml(
@@ -60,28 +65,31 @@ def test_load_plugin_from_yaml_bad_parameters(mocker):
     assert isinstance(res, NoopPlugin)
 
 def test_load_plugin_from_yaml_missing_params(mocker):
-    class SampleModule(object):
-        class SamplePlugin(object):
-            def __init__(self):
-                pass
+    class SamplePlugin(object):
+        def __init__(self):
+            pass
+    
+    SampleModule = mocker.MagicMock(SamplePlugin=SamplePlugin)
+
 
     mocker.patch("codecov_cli.plugins.import_module", return_value=SampleModule)
     res = _load_plugin_from_yaml(
         {"module": "a", "class": "SamplePlugin"}
     )
-    assert isinstance(res, SampleModule.SamplePlugin)
+    assert isinstance(res, SamplePlugin)
 
 def test_load_plugin_from_yaml_empty_params(mocker):
-    class SampleModule(object):
-        class SamplePlugin(object):
-            def __init__(self):
-                pass
+    class SamplePlugin(object):
+        def __init__(self):
+            pass
+    
+    SampleModule = mocker.MagicMock(SamplePlugin=SamplePlugin)
 
     mocker.patch("codecov_cli.plugins.import_module", return_value=SampleModule)
     res = _load_plugin_from_yaml(
         {"module": "a", "class": "SamplePlugin", "params" : {}}
     )
-    assert isinstance(res, SampleModule.SamplePlugin)
+    assert isinstance(res, SamplePlugin)
 
 def test_get_plugin_gcov():
     res = _get_plugin({}, "gcov")
@@ -119,15 +127,18 @@ def test_get_plugin_compress_pycoverage():
 
 
 def test_select_preparation_plugins(mocker):
-    class SampleModule(object):
-        class SamplePlugin(object):
-            def __init__(self, banana=None):
-                pass
+    class SamplePlugin(object):
+        def __init__(self, banana=None):
+            pass
+    
+    SampleModule = mocker.MagicMock(SamplePlugin=SamplePlugin)
 
-    class SecondSampleModule(object):
-        class SecondSamplePlugin(object):
-            def __init__(self, banana=None):
-                pass
+    class SecondSamplePlugin(object):
+        def __init__(self, banana=None):
+            pass
+
+    SecondSampleModule = mocker.MagicMock(SecondSamplePlugin=SecondSamplePlugin)
+    
 
     mocker.patch(
         "codecov_cli.plugins.import_module",
@@ -152,5 +163,5 @@ def test_select_preparation_plugins(mocker):
     assert isinstance(res[0], GcovPlugin)
     assert isinstance(res[1], NoopPlugin)
     assert isinstance(res[2], NoopPlugin)
-    assert isinstance(res[3], SecondSampleModule.SecondSamplePlugin)
+    assert isinstance(res[3], SecondSamplePlugin)
     assert isinstance(res[4], NoopPlugin)


### PR DESCRIPTION
This PR implements a fix for the incorrect custom plugin path config field, by removing the incorrect field and replacing it with a field for the module and a field for class.

This PR also implements a fix for handling cases where the custom plugin params field is missing or empty.  

Fixes: #60 