### PR TITLE
Call static analysis finish endpoint after uploading files

### DIFF
--- a/codecov_cli/services/staticanalysis/__init__.py
+++ b/codecov_cli/services/staticanalysis/__init__.py
@@ -140,26 +140,12 @@ async def run_analysis_entrypoint(
     else:
         logger.info("All files are already uploaded!")
     try:
-        external_id = response_json["external_id"]
-        logger.debug(
-            "Sending finish signal to let API know to schedule static analysis task",
-            extra=dict(extra_log_attributes=dict(external_id=external_id)),
-        )
-        upload_url = enterprise_url or CODECOV_API_URL
-        response = requests.post(
-            f"{upload_url}/staticanalysis/analyses/{external_id}/finish",
-            headers={"Authorization": f"Repotoken {token}"},
-        )
-        if response.status_code >= 500:
-            raise click.ClickException("Sorry. Codecov is having problems")
-        if response.status_code >= 400:
-            raise click.ClickException(
-                f"There is some problem with the submitted information.\n{response_json.get('detail')}"
-            )
+        response = send_finish_signal(response_json, upload_url, token)
     except requests.RequestException:
         raise click.ClickException(click.style("Unable to reach Codecov", fg="red"))
     logger.info(
-        "Received response from server",
+        "Received response with status code %s from server",
+        response.status_code,
         extra=dict(
             extra_log_attributes=dict(time_taken=response.elapsed.total_seconds())
         ),
@@ -198,6 +184,25 @@ async def send_single_upload_put(client, all_data, el):
         "filepath": el["filepath"],
         "succeeded": False,
     }
+
+
+def send_finish_signal(response_json, upload_url: str, token: str):
+    external_id = response_json["external_id"]
+    logger.debug(
+        "Sending finish signal to let API know to schedule static analysis task",
+        extra=dict(extra_log_attributes=dict(external_id=external_id)),
+    )
+    response = requests.post(
+        f"{upload_url}/staticanalysis/analyses/{external_id}/finish",
+        headers={"Authorization": f"Repotoken {token}"},
+    )
+    if response.status_code >= 500:
+        raise click.ClickException("Sorry. Codecov is having problems")
+    if response.status_code >= 400:
+        raise click.ClickException(
+            f"There is some problem with the submitted information.\n{response_json.get('detail')}"
+        )
+    return response
 
 
 def analyze_file(config, filename: FileAnalysisRequest):

--- a/tests/services/static_analysis/test_static_analysis_service.py
+++ b/tests/services/static_analysis/test_static_analysis_service.py
@@ -1,9 +1,12 @@
 from pathlib import Path
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock
 
 import pytest
+import requests
 import responses
 from responses import matchers
+
+import click
 
 from codecov_cli.services.staticanalysis import run_analysis_entrypoint
 from codecov_cli.services.staticanalysis.types import FileAnalysisRequest
@@ -18,6 +21,7 @@ class TestStaticAnalysisService:
         mock_send_upload_put = mocker.patch(
             "codecov_cli.services.staticanalysis.send_single_upload_put"
         )
+
         # Doing it this way to support Python 3.7
         async def side_effect(*args, **kwargs):
             return MagicMock()
@@ -37,6 +41,7 @@ class TestStaticAnalysisService:
                 responses.POST,
                 "https://api.codecov.io/staticanalysis/analyses",
                 json={
+                    "external_id": "externalid",
                     "filepaths": [
                         {
                             "state": "created",
@@ -48,13 +53,22 @@ class TestStaticAnalysisService:
                             "filepath": "samples/inputs/sample_002.py",
                             "raw_upload_location": "http://storage-url",
                         },
-                    ]
+                    ],
                 },
                 status=200,
                 match=[
                     matchers.header_matcher({"Authorization": "Repotoken STATIC_TOKEN"})
                 ],
             )
+            rsps.add(
+                responses.POST,
+                "https://api.codecov.io/staticanalysis/analyses/externalid/finish",
+                status=204,
+                match=[
+                    matchers.header_matcher({"Authorization": "Repotoken STATIC_TOKEN"})
+                ],
+            )
+
             await run_analysis_entrypoint(
                 config={},
                 folder=".",
@@ -77,13 +91,23 @@ class TestStaticAnalysisService:
         }
 
     @pytest.mark.asyncio
-    async def test_static_analysis_service_should_force_option(self, mocker):
+    @pytest.mark.parametrize(
+        "finish_endpoint_response,expected",
+        [
+            (500, "Codecov is having problems"),
+            (400, "some problem with the submitted information"),
+        ],
+    )
+    async def test_static_analysis_service_finish_fails_status_code(
+        self, mocker, finish_endpoint_response, expected
+    ):
         mock_file_finder = mocker.patch(
             "codecov_cli.services.staticanalysis.select_file_finder"
         )
         mock_send_upload_put = mocker.patch(
             "codecov_cli.services.staticanalysis.send_single_upload_put"
         )
+
         # Doing it this way to support Python 3.7
         async def side_effect(*args, **kwargs):
             return MagicMock()
@@ -103,6 +127,7 @@ class TestStaticAnalysisService:
                 responses.POST,
                 "https://api.codecov.io/staticanalysis/analyses",
                 json={
+                    "external_id": "externalid",
                     "filepaths": [
                         {
                             "state": "created",
@@ -114,9 +139,168 @@ class TestStaticAnalysisService:
                             "filepath": "samples/inputs/sample_002.py",
                             "raw_upload_location": "http://storage-url",
                         },
-                    ]
+                    ],
                 },
                 status=200,
+                match=[
+                    matchers.header_matcher({"Authorization": "Repotoken STATIC_TOKEN"})
+                ],
+            )
+            rsps.add(
+                responses.POST,
+                "https://api.codecov.io/staticanalysis/analyses/externalid/finish",
+                status=finish_endpoint_response,
+                match=[
+                    matchers.header_matcher({"Authorization": "Repotoken STATIC_TOKEN"})
+                ],
+            )
+            with pytest.raises(click.ClickException, match=expected):
+                await run_analysis_entrypoint(
+                    config={},
+                    folder=".",
+                    numberprocesses=1,
+                    pattern="*.py",
+                    token="STATIC_TOKEN",
+                    commit="COMMIT",
+                    should_force=False,
+                    folders_to_exclude=[],
+                    enterprise_url=None,
+                )
+        mock_file_finder.assert_called_with({})
+        mock_file_finder.return_value.find_files.assert_called()
+        assert mock_send_upload_put.call_count == 1
+        args, _ = mock_send_upload_put.call_args
+        assert args[2] == {
+            "state": "created",
+            "filepath": "samples/inputs/sample_001.py",
+            "raw_upload_location": "http://storage-url",
+        }
+
+    @pytest.mark.asyncio
+    async def test_static_analysis_service_finish_fails_request_exception(self, mocker):
+        mock_file_finder = mocker.patch(
+            "codecov_cli.services.staticanalysis.select_file_finder"
+        )
+        mock_send_upload_put = mocker.patch(
+            "codecov_cli.services.staticanalysis.send_single_upload_put"
+        )
+
+        # Doing it this way to support Python 3.7
+        async def side_effect(*args, **kwargs):
+            return MagicMock()
+
+        mock_send_upload_put.side_effect = side_effect
+
+        files_found = map(
+            lambda filename: FileAnalysisRequest(str(filename), Path(filename)),
+            [
+                "samples/inputs/sample_001.py",
+                "samples/inputs/sample_002.py",
+            ],
+        )
+        mock_file_finder.return_value.find_files = MagicMock(return_value=files_found)
+        with responses.RequestsMock() as rsps:
+            rsps.add(
+                responses.POST,
+                "https://api.codecov.io/staticanalysis/analyses",
+                json={
+                    "external_id": "externalid",
+                    "filepaths": [
+                        {
+                            "state": "created",
+                            "filepath": "samples/inputs/sample_001.py",
+                            "raw_upload_location": "http://storage-url",
+                        },
+                        {
+                            "state": "valid",
+                            "filepath": "samples/inputs/sample_002.py",
+                            "raw_upload_location": "http://storage-url",
+                        },
+                    ],
+                },
+                status=200,
+                match=[
+                    matchers.header_matcher({"Authorization": "Repotoken STATIC_TOKEN"})
+                ],
+            )
+            rsps.add(
+                responses.POST,
+                "https://api.codecov.io/staticanalysis/analyses/externalid/finish",
+                body=requests.RequestException(),
+            )
+            with pytest.raises(click.ClickException, match="Unable to reach Codecov"):
+                await run_analysis_entrypoint(
+                    config={},
+                    folder=".",
+                    numberprocesses=1,
+                    pattern="*.py",
+                    token="STATIC_TOKEN",
+                    commit="COMMIT",
+                    should_force=False,
+                    folders_to_exclude=[],
+                    enterprise_url=None,
+                )
+        mock_file_finder.assert_called_with({})
+        mock_file_finder.return_value.find_files.assert_called()
+        assert mock_send_upload_put.call_count == 1
+        args, _ = mock_send_upload_put.call_args
+        assert args[2] == {
+            "state": "created",
+            "filepath": "samples/inputs/sample_001.py",
+            "raw_upload_location": "http://storage-url",
+        }
+
+    @pytest.mark.asyncio
+    async def test_static_analysis_service_should_force_option(self, mocker):
+        mock_file_finder = mocker.patch(
+            "codecov_cli.services.staticanalysis.select_file_finder"
+        )
+        mock_send_upload_put = mocker.patch(
+            "codecov_cli.services.staticanalysis.send_single_upload_put"
+        )
+
+        # Doing it this way to support Python 3.7
+        async def side_effect(*args, **kwargs):
+            return MagicMock()
+
+        mock_send_upload_put.side_effect = side_effect
+
+        files_found = map(
+            lambda filename: FileAnalysisRequest(str(filename), Path(filename)),
+            [
+                "samples/inputs/sample_001.py",
+                "samples/inputs/sample_002.py",
+            ],
+        )
+        mock_file_finder.return_value.find_files = MagicMock(return_value=files_found)
+        with responses.RequestsMock() as rsps:
+            rsps.add(
+                responses.POST,
+                "https://api.codecov.io/staticanalysis/analyses",
+                json={
+                    "external_id": "externalid",
+                    "filepaths": [
+                        {
+                            "state": "created",
+                            "filepath": "samples/inputs/sample_001.py",
+                            "raw_upload_location": "http://storage-url",
+                        },
+                        {
+                            "state": "valid",
+                            "filepath": "samples/inputs/sample_002.py",
+                            "raw_upload_location": "http://storage-url",
+                        },
+                    ],
+                },
+                status=200,
+                match=[
+                    matchers.header_matcher({"Authorization": "Repotoken STATIC_TOKEN"})
+                ],
+            )
+            rsps.add(
+                responses.POST,
+                "https://api.codecov.io/staticanalysis/analyses/externalid/finish",
+                status=204,
                 match=[
                     matchers.header_matcher({"Authorization": "Repotoken STATIC_TOKEN"})
                 ],
@@ -135,3 +319,74 @@ class TestStaticAnalysisService:
         mock_file_finder.assert_called_with({})
         mock_file_finder.return_value.find_files.assert_called()
         assert mock_send_upload_put.call_count == 2
+
+    @pytest.mark.asyncio
+    async def test_static_analysis_service_no_upload(self, mocker):
+        mock_file_finder = mocker.patch(
+            "codecov_cli.services.staticanalysis.select_file_finder"
+        )
+        mock_send_upload_put = mocker.patch(
+            "codecov_cli.services.staticanalysis.send_single_upload_put"
+        )
+
+        # Doing it this way to support Python 3.7
+        async def side_effect(*args, **kwargs):
+            return MagicMock()
+
+        mock_send_upload_put.side_effect = side_effect
+
+        files_found = map(
+            lambda filename: FileAnalysisRequest(str(filename), Path(filename)),
+            [
+                "samples/inputs/sample_001.py",
+                "samples/inputs/sample_002.py",
+            ],
+        )
+        mock_file_finder.return_value.find_files = MagicMock(return_value=files_found)
+        with responses.RequestsMock() as rsps:
+            rsps.add(
+                responses.POST,
+                "https://api.codecov.io/staticanalysis/analyses",
+                json={
+                    "external_id": "externalid",
+                    "filepaths": [
+                        {
+                            "state": "valid",
+                            "filepath": "samples/inputs/sample_001.py",
+                            "raw_upload_location": "http://storage-url",
+                        },
+                        {
+                            "state": "valid",
+                            "filepath": "samples/inputs/sample_002.py",
+                            "raw_upload_location": "http://storage-url",
+                        },
+                    ],
+                },
+                status=200,
+                match=[
+                    matchers.header_matcher({"Authorization": "Repotoken STATIC_TOKEN"})
+                ],
+            )
+            rsps.add(
+                responses.POST,
+                "https://api.codecov.io/staticanalysis/analyses/externalid/finish",
+                status=204,
+                match=[
+                    matchers.header_matcher({"Authorization": "Repotoken STATIC_TOKEN"})
+                ],
+            )
+
+            await run_analysis_entrypoint(
+                config={},
+                folder=".",
+                numberprocesses=1,
+                pattern="*.py",
+                token="STATIC_TOKEN",
+                commit="COMMIT",
+                should_force=False,
+                folders_to_exclude=[],
+                enterprise_url=None,
+            )
+        mock_file_finder.assert_called_with({})
+        mock_file_finder.return_value.find_files.assert_called()
+        assert mock_send_upload_put.call_count == 0


### PR DESCRIPTION
This commit changes the static-analysis command in the CLI, such that it calls the staticanalysis/analyses/<external_id>/finish endpoint in the API after it uploads the necessary files. This endpoint schedules the static analysis task on the worker immediately.

Fixes: #66