### PR TITLE
Send labels to Codecov only after collecting them

### DIFF
--- a/tests/services/static_analysis/test_static_analysis_service.py
+++ b/tests/services/static_analysis/test_static_analysis_service.py
@@ -1,12 +1,11 @@
 from pathlib import Path
 from unittest.mock import MagicMock
 
+import click
 import pytest
 import requests
 import responses
 from responses import matchers
-
-import click
 
 from codecov_cli.services.staticanalysis import run_analysis_entrypoint
 from codecov_cli.services.staticanalysis.types import FileAnalysisRequest


### PR DESCRIPTION
These changes alter the way label analysis command works by making 2 requests to Codecov instead of 1.

Why would we want to do this, if it's more time to make a second request?
Because it takes (usually) longer to collect the labels than it takes to make a second request.
Specially for bigger repos, collecting the labels can take dozens of seconds.
By making the label collection parallel with the labels processing we can speed up the total ATS time.

We still PATCH the labels in case the worker hasn't finished the calculations, and it will
correctly refresh the request labels from the DB (based on [here](https://github.com/codecov/worker/pull/1210)).
However even if it misses the requested labels we recalculate the `absent_labels`, if needed (`_potentially_calculate_absent_labels`).

So we still guarantee the exact same response everytime. Potentially faster.

PS.: The file `test_instantiation.py` changes because of the linter