### PR TITLE
Pin dependencies in setup.py and separate dev deps

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -1,11 +1,5 @@
-click
+.
 pytest
 pytest-cov
 pytest-mock
 pytest-asyncio
-pyyaml
-responses
-httpx
-tree_sitter
-ijson
-smart-open

--- a/setup.py
+++ b/setup.py
@@ -14,10 +14,18 @@ setup(
     packages=find_packages(exclude=["contrib", "docs", "tests*"]),
     description="Codecov Command Line Interface",
     long_description=long_description,
-    long_description_content_type='text/markdown',
+    long_description_content_type="text/markdown",
     author="Codecov",
     author_email="support@codecov.io",
-    install_requires=["click", "requests", "PyYAML", "tree_sitter", "httpx", "pytest", "pytest-cov", "ijson", "smart-open"],
+    install_requires=[
+        "click==8.*",
+        "httpx==0.23.*",
+        "ijson==3.*",
+        "pyyaml==6.*",
+        "responses==0.21.*",
+        "smart-open==6.*",
+        "tree-sitter==0.20.*",
+    ],
     entry_points={
         "console_scripts": [
             "codecovcli = codecov_cli.main:run",


### PR DESCRIPTION
This PR pins the dependencies versions in setup.py. These dependency versions are generated by pip-compile.

This PR separates the dev dependencies into a separate dev.txt file. This file is generated by using the `pip-compile` command on the `dev.in` file.

This PR introduces a script to generate the list of dependencies in `requirements.txt` with  their versions pinned to be copied into the `setup.py` file.

This PR modifies the push GHA to use `dev.txt` instead of `requirements.txt` to install dependencies

Fixes: https://github.com/codecov/codecov-cli/issues/189