### PR TITLE
Complete upload command

### DIFF
--- a/codecov_cli/commands/upload_completion.py
+++ b/codecov_cli/commands/upload_completion.py
@@ -1,0 +1,68 @@
+import logging
+import typing
+import uuid
+
+import click
+
+from codecov_cli.fallbacks import CodecovOption, FallbackFieldEnum
+from codecov_cli.helpers.git import GitService
+from codecov_cli.services.upload_completion import upload_completion_logic
+
+logger = logging.getLogger("codecovcli")
+
+
+@click.command()
+@click.option(
+    "-C",
+    "--sha",
+    "--commit-sha",
+    "commit_sha",
+    help="Commit SHA (with 40 chars)",
+    cls=CodecovOption,
+    fallback_field=FallbackFieldEnum.commit_sha,
+    required=True,
+)
+@click.option(
+    "-r",
+    "--slug",
+    "slug",
+    cls=CodecovOption,
+    fallback_field=FallbackFieldEnum.slug,
+    help="owner/repo slug used instead of the private repo token in Self-hosted",
+    envvar="CODECOV_SLUG",
+)
+@click.option(
+    "-t",
+    "--token",
+    help="Codecov upload token",
+    type=click.UUID,
+    envvar="CODECOV_TOKEN",
+)
+@click.option(
+    "--git-service",
+    cls=CodecovOption,
+    fallback_field=FallbackFieldEnum.git_service,
+    type=click.Choice(service.value for service in GitService),
+)
+@click.pass_context
+def upload_completion(
+    ctx,
+    commit_sha: str,
+    slug: typing.Optional[str],
+    token: typing.Optional[uuid.UUID],
+    git_service: typing.Optional[str],
+):
+    enterprise_url = ctx.obj.get("enterprise_url")
+    logger.debug(
+        "Completing upload process",
+        extra=dict(
+            extra_log_attributes=dict(
+                commit_sha=commit_sha,
+                slug=slug,
+                token=token,
+                service=git_service,
+                enterprise_url=enterprise_url,
+            )
+        ),
+    )
+    return upload_completion_logic(commit_sha, slug, token, git_service, enterprise_url)

--- a/codecov_cli/main.py
+++ b/codecov_cli/main.py
@@ -13,6 +13,7 @@ from codecov_cli.commands.labelanalysis import label_analysis
 from codecov_cli.commands.report import create_report
 from codecov_cli.commands.staticanalysis import static_analysis
 from codecov_cli.commands.upload import do_upload
+from codecov_cli.commands.upload_completion import upload_completion
 from codecov_cli.commands.upload_process import upload_process
 from codecov_cli.helpers.ci_adapters import get_ci_adapter, get_ci_providers_list
 from codecov_cli.helpers.config import load_cli_config
@@ -69,6 +70,7 @@ cli.add_command(label_analysis)
 cli.add_command(static_analysis)
 cli.add_command(empty_upload)
 cli.add_command(upload_process)
+cli.add_command(upload_completion)
 
 
 def run():

--- a/codecov_cli/services/upload_completion/__init__.py
+++ b/codecov_cli/services/upload_completion/__init__.py
@@ -1,0 +1,25 @@
+import json
+import logging
+
+from codecov_cli.helpers.config import CODECOV_API_URL
+from codecov_cli.helpers.encoder import encode_slug
+from codecov_cli.helpers.request import (
+    get_token_header_or_fail,
+    log_warnings_and_errors_if_any,
+    send_post_request,
+)
+
+logger = logging.getLogger("codecovcli")
+
+
+def upload_completion_logic(commit_sha, slug, token, git_service, enterprise_url):
+    encoded_slug = encode_slug(slug)
+    headers = get_token_header_or_fail(token)
+    upload_url = enterprise_url or CODECOV_API_URL
+    url = f"{upload_url}/upload/{git_service}/{encoded_slug}/commits/{commit_sha}/upload-complete"
+    sending_result = send_post_request(url=url, headers=headers)
+    log_warnings_and_errors_if_any(sending_result, "Upload Completion")
+    if sending_result.status_code == 200:
+        response_json = json.loads(sending_result.text)
+        logger.info(response_json.get("result"))
+    return sending_result

--- a/tests/services/static_analysis/test_static_analysis_service.py
+++ b/tests/services/static_analysis/test_static_analysis_service.py
@@ -1,12 +1,11 @@
 from pathlib import Path
 from unittest.mock import MagicMock
 
+import click
 import pytest
 import requests
 import responses
 from responses import matchers
-
-import click
 
 from codecov_cli.services.staticanalysis import run_analysis_entrypoint
 from codecov_cli.services.staticanalysis.types import FileAnalysisRequest

--- a/tests/services/upload_completion/test_upload_completion.py
+++ b/tests/services/upload_completion/test_upload_completion.py
@@ -1,0 +1,102 @@
+import json
+import uuid
+
+from click.testing import CliRunner
+
+from codecov_cli.services.upload_completion import upload_completion_logic
+from codecov_cli.types import RequestError, RequestResult, RequestResultWarning
+from tests.test_helpers import parse_outstreams_into_log_lines
+
+
+def test_upload_completion_with_warnings(mocker):
+    mock_send_commit_data = mocker.patch(
+        "codecov_cli.services.upload_completion.send_post_request",
+        return_value=RequestResult(
+            error=None,
+            warnings=[RequestResultWarning(message="somewarningmessage")],
+            status_code=201,
+            text="",
+        ),
+    )
+    runner = CliRunner()
+    with runner.isolation() as outstreams:
+        res = upload_completion_logic(
+            "commit_sha", "owner/repo", uuid.uuid4(), "service", None
+        )
+    out_bytes = parse_outstreams_into_log_lines(outstreams[0].getvalue())
+    assert out_bytes == [
+        ("info", "Process Upload Completion complete"),
+        ("info", "Upload Completion process had 1 warning"),
+        ("warning", "Warning 1: somewarningmessage"),
+    ]
+    assert res == mock_send_commit_data.return_value
+    mock_send_commit_data.assert_called_once()
+
+
+def test_upload_completion_with_error(mocker):
+    mock_send_commit_data = mocker.patch(
+        "codecov_cli.services.upload_completion.send_post_request",
+        return_value=RequestResult(
+            error=RequestError(
+                code="HTTP Error 403",
+                description="Permission denied",
+                params={},
+            ),
+            warnings=[],
+            status_code=403,
+            text="Permission denied",
+        ),
+    )
+    runner = CliRunner()
+    with runner.isolation() as outstreams:
+        res = upload_completion_logic(
+            "commit_sha", "owner/repo", uuid.uuid4(), "service", None
+        )
+    out_bytes = parse_outstreams_into_log_lines(outstreams[0].getvalue())
+    assert out_bytes == [
+        ("info", "Process Upload Completion complete"),
+        ("error", "Upload Completion failed: Permission denied"),
+    ]
+    assert res == mock_send_commit_data.return_value
+    mock_send_commit_data.assert_called_once()
+
+
+def test_upload_completion_200(mocker):
+    res = {
+        "result": "All changed files are ignored. Triggering passing notifications.",
+    }
+    mocked_response = mocker.patch(
+        "codecov_cli.helpers.request.requests.post",
+        return_value=RequestResult(
+            status_code=200, error=None, warnings=[], text=json.dumps(res)
+        ),
+    )
+    token = uuid.uuid4()
+    runner = CliRunner()
+    with runner.isolation() as outstreams:
+        res = upload_completion_logic(
+            "commit_sha", "owner/repo", token, "service", None
+        )
+    out_bytes = parse_outstreams_into_log_lines(outstreams[0].getvalue())
+    assert out_bytes == [
+        ("info", "Process Upload Completion complete"),
+        ("info", "All changed files are ignored. Triggering passing notifications."),
+    ]
+    assert res.error is None
+    assert res.warnings == []
+    mocked_response.assert_called_once()
+
+
+def test_upload_completion_403(mocker):
+    mocked_response = mocker.patch(
+        "codecov_cli.helpers.request.requests.post",
+        return_value=mocker.MagicMock(status_code=403, text="Permission denied"),
+    )
+    token = uuid.uuid4()
+    res = upload_completion_logic("commit_sha", "owner/repo", token, "service", None)
+    assert res.error == RequestError(
+        code="HTTP Error 403",
+        description="Permission denied",
+        params={},
+    )
+    mocked_response.assert_called_once()

--- a/tests/test_codecov_cli.py
+++ b/tests/test_codecov_cli.py
@@ -16,5 +16,6 @@ def test_existing_commands():
         "label-analysis",
         "pr-base-picking",
         "static-analysis",
+        "upload-completion",
         "upload-process",
     ]


### PR DESCRIPTION
creating new command that tells codecov that the user has finished uploading and now wants to get notifications - notifications is part of the api endpoint, not related to this change specifically 
side note: I feel that 'upload-completion' is not a very descriptive name to what we're trying to do here. Do you think we can name it in a more descriptive way? Let me know if you have better ones 