### PR TITLE
Use `LabelAnalysisRequestResult` object

### DIFF
--- a/codecov_cli/runners/python_standard_runner.py
+++ b/codecov_cli/runners/python_standard_runner.py
@@ -185,19 +185,19 @@ class PythonStandardRunner(LabelAnalysisRunnerInterface):
             "Received information about tests to run",
             extra=dict(
                 extra_log_attributes=dict(
-                    absent_labels=len(result["absent_labels"] or []),
-                    present_diff_labels=len(result["present_diff_labels"] or []),
-                    global_level_labels=len(result["global_level_labels"] or []),
-                    present_report_labels=len(result["present_report_labels"] or []),
+                    absent_labels=len(result.absent_labels),
+                    present_diff_labels=len(result.present_diff_labels),
+                    global_level_labels=len(result.global_level_labels),
+                    present_report_labels=len(result.present_report_labels),
                 )
             ),
         )
         all_labels = set(
-            result["absent_labels"]
-            + result["present_diff_labels"]
-            + result["global_level_labels"]
+            result.absent_labels
+            + result.present_diff_labels
+            + result.global_level_labels
         )
-        skipped_tests = set(result["present_report_labels"]) - all_labels
+        skipped_tests = set(result.present_report_labels) - all_labels
         if skipped_tests:
             logger.info(
                 "Some tests are being skipped",
@@ -207,7 +207,7 @@ class PythonStandardRunner(LabelAnalysisRunnerInterface):
             )
 
         if len(all_labels) == 0:
-            all_labels = [random.choice(result["present_report_labels"])]
+            all_labels = [random.choice(result.present_report_labels)]
             logger.info(
                 "All tests are being skipped. Selected random label to run",
                 extra=dict(extra_log_attributes=dict(selected_label=all_labels[0])),

--- a/tests/runners/test_python_standard_runner.py
+++ b/tests/runners/test_python_standard_runner.py
@@ -7,10 +7,10 @@ from pytest import ExitCode
 
 from codecov_cli.runners.python_standard_runner import (
     PythonStandardRunner,
-    PythonStandardRunnerConfigParams,
     _execute_pytest_subprocess,
 )
 from codecov_cli.runners.python_standard_runner import stdout as pyrunner_stdout
+from codecov_cli.runners.types import LabelAnalysisRequestResult
 
 
 @patch("codecov_cli.runners.python_standard_runner.pytest")
@@ -248,7 +248,9 @@ class TestPythonStandardRunner(object):
         }
         mock_execute = mocker.patch.object(PythonStandardRunner, "_execute_pytest")
 
-        self.runner.process_labelanalysis_result(label_analysis_result)
+        self.runner.process_labelanalysis_result(
+            LabelAnalysisRequestResult(label_analysis_result)
+        )
         args, kwargs = mock_execute.call_args
         assert kwargs == {"capture_output": False}
         assert isinstance(args[0], list)
@@ -277,7 +279,9 @@ class TestPythonStandardRunner(object):
 
         runner_config = {"strict_mode": True}
         runner = PythonStandardRunner(runner_config)
-        runner.process_labelanalysis_result(label_analysis_result)
+        runner.process_labelanalysis_result(
+            LabelAnalysisRequestResult(label_analysis_result)
+        )
         mock_execute.assert_not_called()
         args, kwargs = mock_execute_strict.call_args
         assert kwargs == {"capture_output": False}
@@ -302,7 +306,9 @@ class TestPythonStandardRunner(object):
         }
         mock_execute = mocker.patch.object(PythonStandardRunner, "_execute_pytest")
 
-        self.runner.process_labelanalysis_result(label_analysis_result)
+        self.runner.process_labelanalysis_result(
+            LabelAnalysisRequestResult(label_analysis_result)
+        )
         args, kwargs = mock_execute.call_args
         assert kwargs == {"capture_output": False}
         assert isinstance(args[0], list)


### PR DESCRIPTION
instead of using the result as a dictionary we can use it as the object we wrap it into.
There are 2 benefits to this:
1. It's cleaner to read
2. It does the fallback to `[]` if the api returns any of the values as `None`. This avoids a bug we saw yesterday when trying to concatenate list to None.

We do the wrapping in labelanalysis, before passing it to the runner.