### PR TITLE
Allow users to change coverage root for python runner

### DIFF
--- a/codecov_cli/runners/python_standard_runner.py
+++ b/codecov_cli/runners/python_standard_runner.py
@@ -26,6 +26,14 @@ class PythonStandardRunnerConfigParams(dict):
         return self.get("collect_tests_options", [])
 
     @property
+    def coverage_root(self) -> str:
+        """
+        The coverage root. This will be passed to --cov=<coverage_root_dir>
+        Default: ./
+        """
+        return self.get("coverage_root", "./")
+
+    @property
     def strict_mode(self) -> bool:
         """
         Run pytest from within Python instead of using subprocess.run
@@ -180,7 +188,7 @@ class PythonStandardRunner(LabelAnalysisRunnerInterface):
         return test_names
 
     def process_labelanalysis_result(self, result: LabelAnalysisRequestResult):
-        default_options = ["--cov=./", "--cov-context=test"]
+        default_options = [f"--cov={self.params.coverage_root}", "--cov-context=test"]
         logger.info(
             "Received information about tests to run",
             extra=dict(

--- a/tests/services/static_analysis/test_static_analysis_service.py
+++ b/tests/services/static_analysis/test_static_analysis_service.py
@@ -1,12 +1,11 @@
 from pathlib import Path
 from unittest.mock import MagicMock
 
+import click
 import pytest
 import requests
 import responses
 from responses import matchers
-
-import click
 
 from codecov_cli.services.staticanalysis import run_analysis_entrypoint
 from codecov_cli.services.staticanalysis.types import FileAnalysisRequest


### PR DESCRIPTION
Adds the coverage_root config option for PythonStandardRunner so users can override the `--cov=./` option.

Fixes [platform-team #77](https://github.com/codecov/platform-team/issues/77)