### PR TITLE
docs: Add Link to Contributing Repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,6 +243,8 @@ The CLI can perform basic static analysis on Python code today. This static anal
 
 # Contributions
 
+This repository, like all of Codecov's repositories, strives to follow our general [Contributing guidlines](https://github.com/codecov/contributing). If you're considering making a contribution to this repository, we encourage review of our Contributing guidelines first. 
+
 ## Requirements
 
 Most of this package is a very conventional Python package. The main difference is the static the CLI's analysis module uses both git submodules and C code


### PR DESCRIPTION
This PR adds a link to the contributing repo that contains the guidelines for working in the Codecov open source repo.