### PR TITLE
Retry requests on `ConnectionError` and `Timeout`

### DIFF
--- a/tests/helpers/test_request.py
+++ b/tests/helpers/test_request.py
@@ -1,13 +1,24 @@
 import uuid
 
 import pytest
+import requests
+from requests import Response
 
 from codecov_cli.helpers.request import (
     get_token_header_or_fail,
     log_warnings_and_errors_if_any,
 )
 from codecov_cli.helpers.request import logger as req_log
+from codecov_cli.helpers.request import request_result, send_post_request
 from codecov_cli.types import RequestError, RequestResult
+
+
+@pytest.fixture
+def valid_response():
+    valid_response = Response()
+    valid_response.status_code = 200
+    valid_response._content = b"response text"
+    return valid_response
 
 
 def test_log_error_no_raise(mocker):
@@ -54,3 +65,38 @@ def test_get_token_header_or_fail():
         get_token_header_or_fail(token)
 
     assert str(e.value) == f"Token must be UUID. Received {type(token)}"
+
+
+def test_request_retry(mocker, valid_response):
+    expected_response = request_result(valid_response)
+    mock_sleep = mocker.patch("codecov_cli.helpers.request.sleep")
+    mocker.patch.object(
+        requests,
+        "post",
+        side_effect=[
+            requests.exceptions.ConnectionError(),
+            requests.exceptions.Timeout(),
+            valid_response,
+        ],
+    )
+    resp = send_post_request("my_url")
+    assert resp == expected_response
+    mock_sleep.assert_called()
+
+
+def test_request_retry_too_many_errors(mocker):
+    mock_sleep = mocker.patch("codecov_cli.helpers.request.sleep")
+    mocker.patch.object(
+        requests,
+        "post",
+        side_effect=[
+            requests.exceptions.ConnectionError(),
+            requests.exceptions.Timeout(),
+            requests.exceptions.Timeout(),
+            requests.exceptions.Timeout(),
+            requests.exceptions.Timeout(),
+        ],
+    )
+    with pytest.raises(Exception) as exp:
+        resp = send_post_request("my_url")
+    assert str(exp.value) == "Request failed after too many retries"


### PR DESCRIPTION
Adds a retry logic to `send_post_request` and `send_put_request` to retry on ConnectionError and Timeout. Also makes the legacy upload sender use those functions.

There might be a better way to do that without the custom logic, but the `Retry` option I saw you specify retry error codes, and I'm not sure ECONNRESET gives an error code. But apparently it is a `requests.exceptions.COnnectionError`, so...

Fixes uploader #537