### PR TITLE
Enable ATS in the CLI

### DIFF
--- a/.github/workflows/push_flow.yml
+++ b/.github/workflows/push_flow.yml
@@ -84,3 +84,25 @@ jobs:
       - name: Static Analysis
         run: |
           codecovcli static-analysis --token ${{ secrets.STATIC_TOKEN }}
+
+  label-analysis:
+    runs-on: ubuntu-latest
+    needs: static-analysis
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          submodules: true
+          fetch-depth: 0
+      - uses: actions/setup-python@v3
+      - name: Install CLI
+        run: |
+          pip install -r requirements.txt
+          pip install codecov-cli
+      - name: Label Analysis
+        run: |
+          BASE_SHA=$(git merge-base HEAD^ origin/master)
+          echo $BASE_SHA
+          codecovcli label-analysis --token ${{ secrets.STATIC_TOKEN }} --base-sha=$BASE_SHA --max-wait-time=120
+      - name: Upload smart-labels
+        run: |
+          codecovcli --codecov-yml-path=codecov.yml do-upload --plugin pycoverage --plugin compress-pycoverage --fail-on-error -t ${{ secrets.CODECOV_TOKEN }} --flag smart-labels

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,2 +1,16 @@
 ignore:
   - tests/**
+
+beta_groups:
+  - "labels"
+
+flag_management:
+  individual_flags:
+    - name: "smart-labels"
+      carryforward: true
+      carryforward_mode: "labels"
+
+cli:
+  plugins:
+    pycoverage:
+      report_type: "json"

--- a/codecov_cli/commands/upload.py
+++ b/codecov_cli/commands/upload.py
@@ -181,7 +181,7 @@ _global_upload_options = [
         "--git-service",
         cls=CodecovOption,
         fallback_field=FallbackFieldEnum.git_service,
-        type=click.Choice(service.value for service in GitService),
+        type=click.Choice([service.value for service in GitService]),
     ),
 ]
 

--- a/tests/commands/test_invoke_labelanalysis.py
+++ b/tests/commands/test_invoke_labelanalysis.py
@@ -164,7 +164,9 @@ class TestLabelAnalysisCommand(object):
         assert result.exit_code != 0
         assert "Base and head sha can't be the same" in result.output
 
-    def test_invoke_label_analysis(self, get_labelanalysis_deps, mocker):
+    def test_invoke_label_analysis(
+        self, get_labelanalysis_deps, mocker, use_verbose_option
+    ):
         mock_get_runner = get_labelanalysis_deps["mock_get_runner"]
         fake_runner = get_labelanalysis_deps["fake_runner"]
         collected_labels = get_labelanalysis_deps["collected_labels"]
@@ -203,7 +205,7 @@ class TestLabelAnalysisCommand(object):
             cli_runner = CliRunner()
             result = cli_runner.invoke(
                 cli,
-                ["-v", "label-analysis", "--token=STATIC_TOKEN", "--base-sha=BASE_SHA"],
+                ["label-analysis", "--token=STATIC_TOKEN", "--base-sha=BASE_SHA"],
                 obj={},
             )
             assert result.exit_code == 0
@@ -287,7 +289,7 @@ class TestLabelAnalysisCommand(object):
         assert str(exp.value) == "Failed to get list of labels to run"
 
     def test_fallback_collected_labels_covecov_500_error(
-        self, get_labelanalysis_deps, mocker
+        self, get_labelanalysis_deps, mocker, use_verbose_option
     ):
         mock_get_runner = get_labelanalysis_deps["mock_get_runner"]
         fake_runner = get_labelanalysis_deps["fake_runner"]
@@ -304,7 +306,7 @@ class TestLabelAnalysisCommand(object):
             cli_runner = CliRunner()
             result = cli_runner.invoke(
                 cli,
-                ["-v", "label-analysis", "--token=STATIC_TOKEN", "--base-sha=BASE_SHA"],
+                ["label-analysis", "--token=STATIC_TOKEN", "--base-sha=BASE_SHA"],
                 obj={},
             )
             mock_get_runner.assert_called()
@@ -319,7 +321,7 @@ class TestLabelAnalysisCommand(object):
             print(result.output)
         assert result.exit_code == 0
 
-    def test_fallback_dry_run(self, get_labelanalysis_deps, mocker):
+    def test_fallback_dry_run(self, get_labelanalysis_deps, mocker, use_verbose_option):
         mock_get_runner = get_labelanalysis_deps["mock_get_runner"]
         fake_runner = get_labelanalysis_deps["fake_runner"]
         collected_labels = get_labelanalysis_deps["collected_labels"]
@@ -339,7 +341,6 @@ class TestLabelAnalysisCommand(object):
             result = cli_runner.invoke(
                 cli,
                 [
-                    "-v",
                     "label-analysis",
                     "--token=STATIC_TOKEN",
                     "--base-sha=BASE_SHA",
@@ -360,7 +361,7 @@ class TestLabelAnalysisCommand(object):
         assert result.exit_code == 0
 
     def test_fallback_collected_labels_codecov_error_processing_label_analysis(
-        self, get_labelanalysis_deps, mocker
+        self, get_labelanalysis_deps, mocker, use_verbose_option
     ):
         mock_get_runner = get_labelanalysis_deps["mock_get_runner"]
         fake_runner = get_labelanalysis_deps["fake_runner"]
@@ -393,7 +394,7 @@ class TestLabelAnalysisCommand(object):
             cli_runner = CliRunner()
             result = cli_runner.invoke(
                 cli,
-                ["-v", "label-analysis", "--token=STATIC_TOKEN", "--base-sha=BASE_SHA"],
+                ["label-analysis", "--token=STATIC_TOKEN", "--base-sha=BASE_SHA"],
                 obj={},
             )
             mock_get_runner.assert_called()
@@ -409,7 +410,7 @@ class TestLabelAnalysisCommand(object):
         assert result.exit_code == 0
 
     def test_fallback_collected_labels_codecov_max_wait_time_exceeded(
-        self, get_labelanalysis_deps, mocker
+        self, get_labelanalysis_deps, mocker, use_verbose_option
     ):
         mock_get_runner = get_labelanalysis_deps["mock_get_runner"]
         fake_runner = get_labelanalysis_deps["fake_runner"]
@@ -444,7 +445,6 @@ class TestLabelAnalysisCommand(object):
             result = cli_runner.invoke(
                 cli,
                 [
-                    "-v",
                     "label-analysis",
                     "--token=STATIC_TOKEN",
                     "--base-sha=BASE_SHA",
@@ -465,7 +465,7 @@ class TestLabelAnalysisCommand(object):
         )
 
     def test_first_labelanalysis_request_fails_but_second_works(
-        self, get_labelanalysis_deps, mocker
+        self, get_labelanalysis_deps, mocker, use_verbose_option
     ):
         mock_get_runner = get_labelanalysis_deps["mock_get_runner"]
         fake_runner = get_labelanalysis_deps["fake_runner"]
@@ -504,7 +504,7 @@ class TestLabelAnalysisCommand(object):
             cli_runner = CliRunner()
             result = cli_runner.invoke(
                 cli,
-                ["-v", "label-analysis", "--token=STATIC_TOKEN", "--base-sha=BASE_SHA"],
+                ["label-analysis", "--token=STATIC_TOKEN", "--base-sha=BASE_SHA"],
                 obj={},
             )
             assert result.exit_code == 0

--- a/tests/commands/test_invoke_upload.py
+++ b/tests/commands/test_invoke_upload.py
@@ -2,13 +2,13 @@ from click.testing import CliRunner
 
 from codecov_cli.fallbacks import FallbackFieldEnum
 from codecov_cli.main import cli
-from codecov_cli.services.upload import UploadSender
+from codecov_cli.services.upload import UploadCollector, UploadSender
 from codecov_cli.types import RequestError, RequestResult
 from tests.factory import FakeProvider, FakeVersioningSystem
 from tests.test_helpers import parse_outstreams_into_log_lines
 
 
-def test_upload_missing_commit_sha(mocker):
+def test_upload_missing_commit_sha(mocker, use_verbose_option):
     fake_ci_provider = FakeProvider({FallbackFieldEnum.commit_sha: None})
     fake_versioning_system = FakeVersioningSystem({FallbackFieldEnum.commit_sha: None})
     mocker.patch(
@@ -16,7 +16,7 @@ def test_upload_missing_commit_sha(mocker):
     )
     mocker.patch("codecov_cli.main.get_ci_adapter", return_value=fake_ci_provider)
     runner = CliRunner()
-    result = runner.invoke(cli, ["-v", "do-upload"], obj={})
+    result = runner.invoke(cli, ["do-upload"], obj={})
     assert result.exit_code != 0
     print(result.output)
     assert "Missing option '-C' / '--sha' / '--commit-sha'" in result.output
@@ -32,9 +32,14 @@ def test_upload_raise_Z_option(mocker):
     upload_sender = mocker.patch.object(
         UploadSender, "send_upload_data", return_value=result
     )
+    upload_collector = mocker.patch.object(UploadCollector, "generate_upload_data")
+    fake_ci_provider = FakeProvider({FallbackFieldEnum.commit_sha: None})
+    mocker.patch("codecov_cli.main.get_ci_adapter", return_value=fake_ci_provider)
+
     runner = CliRunner()
     result = runner.invoke(cli, ["do-upload", "--fail-on-error"], obj={})
-    upload_sender.assert_called
+    upload_sender.assert_called()
+    upload_collector.assert_called()
     assert ("error", "Upload failed: Unauthorized") in parse_outstreams_into_log_lines(
         result.output
     )

--- a/tests/commands/test_invoke_upload_process.py
+++ b/tests/commands/test_invoke_upload_process.py
@@ -22,7 +22,7 @@ def test_upload_process_missing_commit_sha(mocker):
         assert "Missing option '-C' / '--sha' / '--commit-sha'" in result.output
 
 
-def test_upload_process_raise_Z_option(mocker):
+def test_upload_process_raise_Z_option(mocker, use_verbose_option):
     error = RequestError(
         code=401, params={"some": "params"}, description="Unauthorized"
     )
@@ -39,7 +39,6 @@ def test_upload_process_raise_Z_option(mocker):
             result = runner.invoke(
                 cli,
                 [
-                    "-v",
                     "upload-process",
                     "--fail-on-error",
                     "-C",
@@ -112,7 +111,7 @@ def test_upload_process_options(mocker):
             "  -d, --dry-run                   Don't upload files to Codecov",
             "  --legacy, --use-legacy-uploader",
             "                                  Use the legacy upload endpoint",
-            "  --git-service []",
+            "  --git-service [github|gitlab|bitbucket|github_enterprise|gitlab_enterprise|bitbucket_server]",
             "  --parent-sha TEXT               SHA (with 40 chars) of what should be the",
             "                                  parent of this commit",
             "  -h, --help                      Show this message and exit.",

--- a/tests/helpers/test_git.py
+++ b/tests/helpers/test_git.py
@@ -23,7 +23,7 @@ from codecov_cli.helpers import git
             "username-codecov/fasdf.git.git",
         ),
         (
-            "https://gitlab-ci-token:[MASKED]@gitlab.com/abc_xyz/testing_env_vars.git",
+            "https://gitlab-ci-token:testtokenaaabbbccc@gitlab.com/abc_xyz/testing_env_vars.git",
             "abc_xyz/testing_env_vars",
         ),
         ("git@github.com:codecov/codecov-cli.git/", "codecov/codecov-cli"),
@@ -88,7 +88,7 @@ def test_parse_slug_invalid_address(address):
             "bitbucket",
         ),
         (
-            "https://gitlab-ci-token:[MASKED]@gitlab.com/abc_xyz/testing_env_vars.git",
+            "https://gitlab-ci-token:testtokenaabbcc@gitlab.com/abc_xyz/testing_env_vars.git",
             "gitlab",
         ),
         ("git@github.com:codecov/codecov-cli.git/", "github"),


### PR DESCRIPTION
Changing tests that used the `-v` option (invoking the CLI) to instead use the fixture. This prevents tests from messing up the global env across tests when running pytest using ATS. As we've been discovering recently, it's a big mess sometimes.

The removal of "MASKED" from some git tests is because it was throwing errors in CI. Maybe it's a python 3.11.x thing... But I suppose they changed when the removal of secrets run. I changed for bogus secrets.

THe git services was also an error, so I had to put them in a list.