### PR TITLE
bazel creates lcov ceverage files with pylcov filename. 

### DIFF
--- a/codecov_cli/services/upload/coverage_file_finder.py
+++ b/codecov_cli/services/upload/coverage_file_finder.py
@@ -26,6 +26,7 @@ coverage_files_patterns = [
     "gcov.info",
     "jacoco*.xml",
     "lcov.dat",
+    "pylcov.dat",
     "lcov.info",
     "luacov.report.out",
     "naxsi.info",


### PR DESCRIPTION
Adding pylcov.dat to the list of coverage files to search for. 