### PR TITLE
cleaner exception log

### DIFF
--- a/codecov_cli/helpers/request.py
+++ b/codecov_cli/helpers/request.py
@@ -2,6 +2,7 @@ import logging
 import uuid
 from time import sleep
 
+import click
 import requests
 
 from codecov_cli.types import RequestError, RequestResult
@@ -46,9 +47,11 @@ def send_post_request(
 
 def get_token_header_or_fail(token: uuid.UUID) -> dict:
     if token is None:
-        raise Exception("Codecov token not found.")
+        raise click.ClickException(
+            "Codecov token not found. Please provide Codecov token with -t flag."
+        )
     if not isinstance(token, uuid.UUID):
-        raise Exception(f"Token must be UUID. Received {type(token)}")
+        raise click.ClickException(f"Token must be UUID. Received {type(token)}")
     return {"Authorization": f"token {token.hex}"}
 
 

--- a/tests/helpers/test_request.py
+++ b/tests/helpers/test_request.py
@@ -57,7 +57,10 @@ def test_get_token_header_or_fail():
     with pytest.raises(Exception) as e:
         get_token_header_or_fail(token)
 
-    assert str(e.value) == "Codecov token not found."
+    assert (
+        str(e.value)
+        == "Codecov token not found. Please provide Codecov token with -t flag."
+    )
 
     # Test with an invalid token type
     token = "invalid_token"


### PR DESCRIPTION
Came across this while integrating this with the bazel stuff. Having the stacktrace in the user's terminal is annoying, so fixing it. 
Raising an exception prints out all stacktrace, which is not practical nor helpful. raising click.Exception only prints out the exception msg
before the change codecovcli create-commit gives the following: 
```
info - 2023-07-24 20:50:53,124 -- ci service found: local
Traceback (most recent call last):
  File "/Users/dana/.pyenv/versions/cli-env-v2/bin/codecovcli", line 33, in <module>
    sys.exit(load_entry_point('codecov-cli', 'console_scripts', 'codecovcli')())
  File "/Users/dana/codecov/codecov-cli/codecov_cli/main.py", line 77, in run
    cli(obj={})
  File "/Users/dana/.pyenv/versions/3.10.5/envs/cli-env-v2/lib/python3.10/site-packages/click/core.py", line 1130, in __call__
    return self.main(*args, **kwargs)
  File "/Users/dana/.pyenv/versions/3.10.5/envs/cli-env-v2/lib/python3.10/site-packages/click/core.py", line 1055, in main
    rv = self.invoke(ctx)
  File "/Users/dana/.pyenv/versions/3.10.5/envs/cli-env-v2/lib/python3.10/site-packages/click/core.py", line 1657, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/Users/dana/.pyenv/versions/3.10.5/envs/cli-env-v2/lib/python3.10/site-packages/click/core.py", line 1404, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/Users/dana/.pyenv/versions/3.10.5/envs/cli-env-v2/lib/python3.10/site-packages/click/core.py", line 760, in invoke
    return __callback(*args, **kwargs)
  File "/Users/dana/.pyenv/versions/3.10.5/envs/cli-env-v2/lib/python3.10/site-packages/click/decorators.py", line 26, in new_func
    return f(get_current_context(), *args, **kwargs)
  File "/Users/dana/codecov/codecov-cli/codecov_cli/commands/commit.py", line 102, in create_commit
    create_commit_logic(
  File "/Users/dana/codecov/codecov-cli/codecov_cli/services/commit/__init__.py", line 28, in create_commit_logic
    sending_result = send_commit_data(
  File "/Users/dana/codecov/codecov-cli/codecov_cli/services/commit/__init__.py", line 52, in send_commit_data
    headers = get_token_header_or_fail(token)
  File "/Users/dana/codecov/codecov-cli/codecov_cli/helpers/request.py", line 49, in get_token_header_or_fail
    raise Exception("Codecov token not found.")
Exception: Codecov token not found.
```
after the change:
```
info - 2023-07-24 21:04:51,355 -- ci service found: local
Error: Codecov token not found. Please provide Codecov token with -t flag.
```