### PR TITLE
Improve label analysis messages

### DIFF
--- a/codecov_cli/runners/python_standard_runner.py
+++ b/codecov_cli/runners/python_standard_runner.py
@@ -189,17 +189,6 @@ class PythonStandardRunner(LabelAnalysisRunnerInterface):
 
     def process_labelanalysis_result(self, result: LabelAnalysisRequestResult):
         default_options = [f"--cov={self.params.coverage_root}", "--cov-context=test"]
-        logger.info(
-            "Received information about tests to run",
-            extra=dict(
-                extra_log_attributes=dict(
-                    absent_labels=len(result.absent_labels),
-                    present_diff_labels=len(result.present_diff_labels),
-                    global_level_labels=len(result.global_level_labels),
-                    present_report_labels=len(result.present_report_labels),
-                )
-            ),
-        )
         all_labels = set(
             result.absent_labels
             + result.present_diff_labels


### PR DESCRIPTION
In particular we will now include the `external_id` of the label analysis request object (so it's easier to find in the logs),
and the processing errors that happened in label analysis task. So the user can better self-support.

I also moved the message about the labels to run from the python runner to the command in general because it's something the user would like to see in general.