### PR TITLE
Fix integrity checking readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,16 +57,16 @@ The binary can be integrity checked using a SHASUM256 and SHASUM256.sig file. Th
 
 ```
 curl https://keybase.io/codecovsecurity/pgp_keys.asc | gpg --no-default-keyring --keyring trustedkeys.gpg --import # One-time step
-curl -Os https://uploader.codecov.io/latest/linux/codecov
-curl -Os https://uploader.codecov.io/latest/linux/codecov.SHA256SUM
-curl -Os https://uploader.codecov.io/latest/linux/codecov.SHA256SUM.sig
+curl -Os https://cli.codecov.io/latest/linux/codecov
+curl -Os https://cli.codecov.io/latest/linux/codecov.SHA256SUM
+curl -Os https://cli.codecov.io/latest/linux/codecov.SHA256SUM.sig
 
 gpgv codecov.SHA256SUM.sig codecov.SHA256SUM
 
 shasum -a 256 -c codecov.SHA256SUM
 ```
 
-For macos you will want to use the macos distributions of the binary (e.g., https://uploader.codecov.io/latest/macos/codecov)
+For macos you will want to use the macos distributions of the binary (e.g., https://cli.codecov.io/latest/macos/codecov)
 
 
 # How to Upload to Codecov


### PR DESCRIPTION
Use cli.codecov.io instead of uploader.codecov.io as example for integrity checking the binary.

When I was integrating this CLI into our CI pipeline, I ran into this error that caused me lots of confusion, since I ended up copy/pasting from the documentation into my CI code. Hopefully this saves someone else the headache.

