### PR TITLE
Add fail-on-error flag to commands that were missing it

### DIFF
--- a/codecov_cli/commands/commit.py
+++ b/codecov_cli/commands/commit.py
@@ -6,22 +6,13 @@ import click
 
 from codecov_cli.fallbacks import CodecovOption, FallbackFieldEnum
 from codecov_cli.helpers.git import GitService
+from codecov_cli.helpers.options import global_options
 from codecov_cli.services.commit import create_commit_logic
 
 logger = logging.getLogger("codecovcli")
 
 
 @click.command()
-@click.option(
-    "-C",
-    "--sha",
-    "--commit-sha",
-    "commit_sha",
-    help="Commit SHA (with 40 chars)",
-    cls=CodecovOption,
-    fallback_field=FallbackFieldEnum.commit_sha,
-    required=True,
-)
 @click.option(
     "--parent-sha",
     help="SHA (with 40 chars) of what should be the parent of this commit",
@@ -42,35 +33,7 @@ logger = logging.getLogger("codecovcli")
     cls=CodecovOption,
     fallback_field=FallbackFieldEnum.branch,
 )
-@click.option(
-    "-r",
-    "--slug",
-    "slug",
-    cls=CodecovOption,
-    fallback_field=FallbackFieldEnum.slug,
-    help="owner/repo slug used instead of the private repo token in Self-hosted",
-    envvar="CODECOV_SLUG",
-)
-@click.option(
-    "-t",
-    "--token",
-    help="Codecov upload token",
-    type=click.UUID,
-    envvar="CODECOV_TOKEN",
-)
-@click.option(
-    "--git-service",
-    cls=CodecovOption,
-    fallback_field=FallbackFieldEnum.git_service,
-    type=click.Choice(service.value for service in GitService),
-)
-@click.option(
-    "-Z",
-    "--fail-on-error",
-    "fail_on_error",
-    is_flag=True,
-    help="Exit with non-zero code in case of error processing.",
-)
+@global_options
 @click.pass_context
 def create_commit(
     ctx,

--- a/codecov_cli/commands/create_report_result.py
+++ b/codecov_cli/commands/create_report_result.py
@@ -5,6 +5,7 @@ import click
 
 from codecov_cli.fallbacks import CodecovOption, FallbackFieldEnum
 from codecov_cli.helpers.git import GitService
+from codecov_cli.helpers.options import global_options
 from codecov_cli.services.report import create_report_results_logic
 
 logger = logging.getLogger("codecovcli")
@@ -12,36 +13,9 @@ logger = logging.getLogger("codecovcli")
 
 @click.command()
 @click.option(
-    "--commit-sha",
-    help="Commit SHA (with 40 chars)",
-    cls=CodecovOption,
-    fallback_field=FallbackFieldEnum.commit_sha,
-    required=True,
-)
-@click.option(
     "--code", help="The code of the report. If unsure, leave default", default="default"
 )
-@click.option(
-    "--slug",
-    cls=CodecovOption,
-    fallback_field=FallbackFieldEnum.slug,
-    help="owner/repo slug used instead of the private repo token in Self-hosted",
-    envvar="CODECOV_SLUG",
-    required=True,
-)
-@click.option(
-    "--git-service",
-    cls=CodecovOption,
-    fallback_field=FallbackFieldEnum.git_service,
-    type=click.Choice(service.value for service in GitService),
-)
-@click.option(
-    "-t",
-    "--token",
-    help="Codecov upload token",
-    type=click.UUID,
-    envvar="CODECOV_TOKEN",
-)
+@global_options
 @click.pass_context
 def create_report_results(
     ctx,
@@ -50,6 +24,7 @@ def create_report_results(
     slug: str,
     git_service: str,
     token: uuid.UUID,
+    fail_on_error: bool,
 ):
     enterprise_url = ctx.obj.get("enterprise_url")
     logger.debug(
@@ -65,5 +40,5 @@ def create_report_results(
         ),
     )
     create_report_results_logic(
-        commit_sha, code, slug, git_service, token, enterprise_url
+        commit_sha, code, slug, git_service, token, enterprise_url, fail_on_error
     )

--- a/codecov_cli/commands/empty_upload.py
+++ b/codecov_cli/commands/empty_upload.py
@@ -6,44 +6,14 @@ import click
 
 from codecov_cli.fallbacks import CodecovOption, FallbackFieldEnum
 from codecov_cli.helpers.git import GitService
+from codecov_cli.helpers.options import global_options
 from codecov_cli.services.empty_upload import empty_upload_logic
 
 logger = logging.getLogger("codecovcli")
 
 
 @click.command()
-@click.option(
-    "-C",
-    "--sha",
-    "--commit-sha",
-    "commit_sha",
-    help="Commit SHA (with 40 chars)",
-    cls=CodecovOption,
-    fallback_field=FallbackFieldEnum.commit_sha,
-    required=True,
-)
-@click.option(
-    "-r",
-    "--slug",
-    "slug",
-    cls=CodecovOption,
-    fallback_field=FallbackFieldEnum.slug,
-    help="owner/repo slug used instead of the private repo token in Self-hosted",
-    envvar="CODECOV_SLUG",
-)
-@click.option(
-    "-t",
-    "--token",
-    help="Codecov upload token",
-    type=click.UUID,
-    envvar="CODECOV_TOKEN",
-)
-@click.option(
-    "--git-service",
-    cls=CodecovOption,
-    fallback_field=FallbackFieldEnum.git_service,
-    type=click.Choice(service.value for service in GitService),
-)
+@global_options
 @click.pass_context
 def empty_upload(
     ctx,

--- a/codecov_cli/commands/get_report_results.py
+++ b/codecov_cli/commands/get_report_results.py
@@ -6,6 +6,7 @@ import click
 from codecov_cli.fallbacks import CodecovOption, FallbackFieldEnum
 from codecov_cli.helpers.encoder import encode_slug
 from codecov_cli.helpers.git import GitService
+from codecov_cli.helpers.options import global_options
 from codecov_cli.services.report import send_reports_result_get_request
 
 logger = logging.getLogger("codecovcli")
@@ -13,36 +14,9 @@ logger = logging.getLogger("codecovcli")
 
 @click.command()
 @click.option(
-    "--commit-sha",
-    help="Commit SHA (with 40 chars)",
-    cls=CodecovOption,
-    fallback_field=FallbackFieldEnum.commit_sha,
-    required=True,
-)
-@click.option(
     "--code", help="The code of the report. If unsure, leave default", default="default"
 )
-@click.option(
-    "--slug",
-    cls=CodecovOption,
-    fallback_field=FallbackFieldEnum.slug,
-    help="owner/repo slug used instead of the private repo token in Self-hosted",
-    envvar="CODECOV_SLUG",
-    required=True,
-)
-@click.option(
-    "--git-service",
-    cls=CodecovOption,
-    fallback_field=FallbackFieldEnum.git_service,
-    type=click.Choice(service.value for service in GitService),
-)
-@click.option(
-    "-t",
-    "--token",
-    help="Codecov upload token",
-    type=click.UUID,
-    envvar="CODECOV_TOKEN",
-)
+@global_options
 @click.pass_context
 def get_report_results(
     ctx,
@@ -51,6 +25,7 @@ def get_report_results(
     slug: str,
     git_service: str,
     token: uuid.UUID,
+    fail_on_error: bool,
 ):
     enterprise_url = ctx.obj.get("enterprise_url")
     logger.debug(
@@ -73,4 +48,5 @@ def get_report_results(
         service=git_service,
         token=token,
         enterprise_url=enterprise_url,
+        fail_on_error=fail_on_error,
     )

--- a/codecov_cli/commands/report.py
+++ b/codecov_cli/commands/report.py
@@ -5,6 +5,7 @@ import click
 
 from codecov_cli.fallbacks import CodecovOption, FallbackFieldEnum
 from codecov_cli.helpers.git import GitService
+from codecov_cli.helpers.options import global_options
 from codecov_cli.services.report import create_report_logic
 
 logger = logging.getLogger("codecovcli")
@@ -12,47 +13,9 @@ logger = logging.getLogger("codecovcli")
 
 @click.command()
 @click.option(
-    "-C",
-    "--sha",
-    "--commit-sha",
-    "commit_sha",
-    help="Commit SHA (with 40 chars)",
-    cls=CodecovOption,
-    fallback_field=FallbackFieldEnum.commit_sha,
-    required=True,
-)
-@click.option(
     "--code", help="The code of the report. If unsure, leave default", default="default"
 )
-@click.option(
-    "-r",
-    "--slug",
-    "slug",
-    cls=CodecovOption,
-    fallback_field=FallbackFieldEnum.slug,
-    help="owner/repo slug used instead of the private repo token in Self-hosted",
-    envvar="CODECOV_SLUG",
-)
-@click.option(
-    "--git-service",
-    cls=CodecovOption,
-    fallback_field=FallbackFieldEnum.git_service,
-    type=click.Choice(service.value for service in GitService),
-)
-@click.option(
-    "-t",
-    "--token",
-    help="Codecov upload token",
-    type=click.UUID,
-    envvar="CODECOV_TOKEN",
-)
-@click.option(
-    "-Z",
-    "--fail-on-error",
-    "fail_on_error",
-    is_flag=True,
-    help="Exit with non-zero code in case of error processing.",
-)
+@global_options
 @click.pass_context
 def create_report(
     ctx,

--- a/codecov_cli/commands/upload.py
+++ b/codecov_cli/commands/upload.py
@@ -7,7 +7,7 @@ import uuid
 import click
 
 from codecov_cli.fallbacks import CodecovOption, FallbackFieldEnum
-from codecov_cli.helpers.git import GitService
+from codecov_cli.helpers.options import global_options
 from codecov_cli.services.upload import do_upload_logic
 
 logger = logging.getLogger("codecovcli")
@@ -18,16 +18,6 @@ def _turn_env_vars_into_dict(ctx, params, value):
 
 
 _global_upload_options = [
-    click.option(
-        "-C",
-        "--sha",
-        "--commit-sha",
-        "commit_sha",
-        help="Commit SHA (with 40 chars)",
-        cls=CodecovOption,
-        fallback_field=FallbackFieldEnum.commit_sha,
-        required=True,
-    ),
     click.option(
         "--report-code",
         help="The code of the report. If unsure, leave default",
@@ -97,13 +87,6 @@ _global_upload_options = [
         fallback_field=FallbackFieldEnum.job_code,
     ),
     click.option(
-        "-t",
-        "--token",
-        help="Codecov upload token",
-        type=click.UUID,
-        envvar="CODECOV_TOKEN",
-    ),
-    click.option(
         "-n",
         "--name",
         help="Custom defined name of the upload. Visible in Codecov UI",
@@ -114,15 +97,6 @@ _global_upload_options = [
         help="Branch to which this commit belongs to",
         cls=CodecovOption,
         fallback_field=FallbackFieldEnum.branch,
-    ),
-    click.option(
-        "-r",
-        "--slug",
-        "slug",
-        cls=CodecovOption,
-        fallback_field=FallbackFieldEnum.slug,
-        help="owner/repo slug used instead of the private repo token in Self-hosted",
-        envvar="CODECOV_SLUG",
     ),
     click.option(
         "-P",
@@ -157,13 +131,6 @@ _global_upload_options = [
         default=["xcode", "gcov", "pycoverage"],
     ),
     click.option(
-        "-Z",
-        "--fail-on-error",
-        "fail_on_error",
-        is_flag=True,
-        help="Exit with non-zero code in case of error uploading.",
-    ),
-    click.option(
         "-d",
         "--dry-run",
         "dry_run",
@@ -177,12 +144,6 @@ _global_upload_options = [
         is_flag=True,
         help="Use the legacy upload endpoint",
     ),
-    click.option(
-        "--git-service",
-        cls=CodecovOption,
-        fallback_field=FallbackFieldEnum.git_service,
-        type=click.Choice([service.value for service in GitService]),
-    ),
 ]
 
 
@@ -194,6 +155,7 @@ def global_upload_options(func):
 
 @click.command()
 @global_upload_options
+@global_options
 @click.pass_context
 def do_upload(
     ctx: click.Context,

--- a/codecov_cli/commands/upload_completion.py
+++ b/codecov_cli/commands/upload_completion.py
@@ -6,44 +6,14 @@ import click
 
 from codecov_cli.fallbacks import CodecovOption, FallbackFieldEnum
 from codecov_cli.helpers.git import GitService
+from codecov_cli.helpers.options import global_options
 from codecov_cli.services.upload_completion import upload_completion_logic
 
 logger = logging.getLogger("codecovcli")
 
 
 @click.command()
-@click.option(
-    "-C",
-    "--sha",
-    "--commit-sha",
-    "commit_sha",
-    help="Commit SHA (with 40 chars)",
-    cls=CodecovOption,
-    fallback_field=FallbackFieldEnum.commit_sha,
-    required=True,
-)
-@click.option(
-    "-r",
-    "--slug",
-    "slug",
-    cls=CodecovOption,
-    fallback_field=FallbackFieldEnum.slug,
-    help="owner/repo slug used instead of the private repo token in Self-hosted",
-    envvar="CODECOV_SLUG",
-)
-@click.option(
-    "-t",
-    "--token",
-    help="Codecov upload token",
-    type=click.UUID,
-    envvar="CODECOV_TOKEN",
-)
-@click.option(
-    "--git-service",
-    cls=CodecovOption,
-    fallback_field=FallbackFieldEnum.git_service,
-    type=click.Choice(service.value for service in GitService),
-)
+@global_options
 @click.pass_context
 def upload_completion(
     ctx,
@@ -51,6 +21,7 @@ def upload_completion(
     slug: typing.Optional[str],
     token: typing.Optional[uuid.UUID],
     git_service: typing.Optional[str],
+    fail_on_error: bool,
 ):
     enterprise_url = ctx.obj.get("enterprise_url")
     logger.debug(
@@ -65,4 +36,11 @@ def upload_completion(
             )
         ),
     )
-    return upload_completion_logic(commit_sha, slug, token, git_service, enterprise_url)
+    return upload_completion_logic(
+        commit_sha,
+        slug,
+        token,
+        git_service,
+        enterprise_url,
+        fail_on_error,
+    )

--- a/codecov_cli/commands/upload_process.py
+++ b/codecov_cli/commands/upload_process.py
@@ -8,11 +8,14 @@ import click
 from codecov_cli.commands.commit import create_commit
 from codecov_cli.commands.report import create_report
 from codecov_cli.commands.upload import do_upload, global_upload_options
+from codecov_cli.helpers.options import global_options
 
 logger = logging.getLogger("codecovcli")
 
+
 # These options are the combined options of commit, report and upload commands
 @click.command()
+@global_options
 @global_upload_options
 @click.option(
     "--parent-sha",

--- a/codecov_cli/helpers/options.py
+++ b/codecov_cli/helpers/options.py
@@ -1,0 +1,52 @@
+import click
+
+from codecov_cli.fallbacks import CodecovOption, FallbackFieldEnum
+from codecov_cli.helpers.git import GitService
+
+_global_options = [
+    click.option(
+        "-C",
+        "--sha",
+        "--commit-sha",
+        "commit_sha",
+        help="Commit SHA (with 40 chars)",
+        cls=CodecovOption,
+        fallback_field=FallbackFieldEnum.commit_sha,
+        required=True,
+    ),
+    click.option(
+        "-Z",
+        "--fail-on-error",
+        "fail_on_error",
+        is_flag=True,
+        help="Exit with non-zero code in case of error",
+    ),
+    click.option(
+        "--git-service",
+        cls=CodecovOption,
+        fallback_field=FallbackFieldEnum.git_service,
+        type=click.Choice([service.value for service in GitService]),
+    ),
+    click.option(
+        "-t",
+        "--token",
+        help="Codecov upload token",
+        type=click.UUID,
+        envvar="CODECOV_TOKEN",
+    ),
+    click.option(
+        "-r",
+        "--slug",
+        "slug",
+        cls=CodecovOption,
+        fallback_field=FallbackFieldEnum.slug,
+        help="owner/repo slug used instead of the private repo token in Self-hosted",
+        envvar="CODECOV_SLUG",
+    ),
+]
+
+
+def global_options(func):
+    for option in reversed(_global_options):
+        func = option(func)
+    return func

--- a/codecov_cli/services/report/__init__.py
+++ b/codecov_cli/services/report/__init__.py
@@ -53,6 +53,7 @@ def create_report_results_logic(
     service: str,
     token: uuid.UUID,
     enterprise_url: str,
+    fail_on_error: bool = False,
 ):
     encoded_slug = encode_slug(slug)
     sending_result = send_reports_result_request(
@@ -64,7 +65,9 @@ def create_report_results_logic(
         enterprise_url=enterprise_url,
     )
 
-    log_warnings_and_errors_if_any(sending_result, "Report results creating")
+    log_warnings_and_errors_if_any(
+        sending_result, "Report results creating", fail_on_error
+    )
     return sending_result
 
 
@@ -78,7 +81,13 @@ def send_reports_result_request(
 
 
 def send_reports_result_get_request(
-    commit_sha, report_code, encoded_slug, service, token, enterprise_url
+    commit_sha,
+    report_code,
+    encoded_slug,
+    service,
+    token,
+    enterprise_url,
+    fail_on_error=False,
 ):
     headers = get_token_header_or_fail(token)
     upload_url = enterprise_url or CODECOV_API_URL
@@ -91,7 +100,9 @@ def send_reports_result_get_request(
 
         # if response_status is 400 and higher
         if response_obj.error:
-            log_warnings_and_errors_if_any(response_obj, "Getting report results")
+            log_warnings_and_errors_if_any(
+                response_obj, "Getting report results", fail_on_error
+            )
             return response_obj
 
         state = response_content.get("state").lower()

--- a/codecov_cli/services/upload_completion/__init__.py
+++ b/codecov_cli/services/upload_completion/__init__.py
@@ -12,13 +12,17 @@ from codecov_cli.helpers.request import (
 logger = logging.getLogger("codecovcli")
 
 
-def upload_completion_logic(commit_sha, slug, token, git_service, enterprise_url):
+def upload_completion_logic(
+    commit_sha, slug, token, git_service, enterprise_url, fail_on_error=False
+):
     encoded_slug = encode_slug(slug)
     headers = get_token_header_or_fail(token)
     upload_url = enterprise_url or CODECOV_API_URL
     url = f"{upload_url}/upload/{git_service}/{encoded_slug}/commits/{commit_sha}/upload-complete"
     sending_result = send_post_request(url=url, headers=headers)
-    log_warnings_and_errors_if_any(sending_result, "Upload Completion")
+    log_warnings_and_errors_if_any(
+        sending_result, "Upload Completion", fail_on_error=fail_on_error
+    )
     if sending_result.status_code == 200:
         response_json = json.loads(sending_result.text)
         logger.info(response_json.get("result"))

--- a/tests/commands/test_invoke_upload_process.py
+++ b/tests/commands/test_invoke_upload_process.py
@@ -19,7 +19,6 @@ def test_upload_process_missing_commit_sha(mocker):
     with runner.isolated_filesystem():
         result = runner.invoke(cli, ["upload-process"], obj={})
         assert result.exit_code != 0
-        assert "Missing option '-C' / '--sha' / '--commit-sha'" in result.output
 
 
 def test_upload_process_raise_Z_option(mocker, use_verbose_option):
@@ -69,6 +68,11 @@ def test_upload_process_options(mocker):
             "",
             "Options:",
             "  -C, --sha, --commit-sha TEXT    Commit SHA (with 40 chars)  [required]",
+            "  -Z, --fail-on-error             Exit with non-zero code in case of error",
+            "  --git-service [github|gitlab|bitbucket|github_enterprise|gitlab_enterprise|bitbucket_server]",
+            "  -t, --token UUID                Codecov upload token",
+            "  -r, --slug TEXT                 owner/repo slug used instead of the private",
+            "                                  repo token in Self-hosted",
             "  --report-code TEXT              The code of the report. If unsure, leave",
             "                                  default",
             "  --network-root-folder PATH      Root folder from which to consider paths on",
@@ -91,12 +95,9 @@ def test_upload_process_options(mocker):
             "  -b, --build, --build-code TEXT  Specify the build number manually",
             "  --build-url TEXT                The URL of the build where this is running",
             "  --job-code TEXT",
-            "  -t, --token UUID                Codecov upload token",
             "  -n, --name TEXT                 Custom defined name of the upload. Visible in",
             "                                  Codecov UI",
             "  -B, --branch TEXT               Branch to which this commit belongs to",
-            "  -r, --slug TEXT                 owner/repo slug used instead of the private",
-            "                                  repo token in Self-hosted",
             "  -P, --pr, --pull-request-number TEXT",
             "                                  Specify the pull request number mannually.",
             "                                  Used to override pre-existing CI environment",
@@ -106,12 +107,9 @@ def test_upload_process_options(mocker):
             "  -F, --flag TEXT                 Flag the upload to group coverage metrics.",
             "                                  Multiple flags allowed.",
             "  --plugin TEXT",
-            "  -Z, --fail-on-error             Exit with non-zero code in case of error",
-            "                                  uploading.",
             "  -d, --dry-run                   Don't upload files to Codecov",
             "  --legacy, --use-legacy-uploader",
             "                                  Use the legacy upload endpoint",
-            "  --git-service [github|gitlab|bitbucket|github_enterprise|gitlab_enterprise|bitbucket_server]",
             "  --parent-sha TEXT               SHA (with 40 chars) of what should be the",
             "                                  parent of this commit",
             "  -h, --help                      Show this message and exit.",


### PR DESCRIPTION
- Creates options.py in commands/helpers
- Moves common options to global_options
- Adds global_options decorators to some subcommands

Fixes: https://github.com/codecov/codecov-cli/issues/208