### PR TITLE
adding errors to extra_log_attributes

### DIFF
--- a/codecov_cli/commands/labelanalysis.py
+++ b/codecov_cli/commands/labelanalysis.py
@@ -181,7 +181,11 @@ def _potentially_calculate_absent_labels(
 ) -> LabelAnalysisRequestResult:
     logger.info(
         "Received list of tests from Codecov",
-        extra=dict(processing_errors=request_result.get("errors", [])),
+        extra=dict(
+            extra_log_attributes=dict(
+                processing_errors=request_result.get("errors", [])
+            )
+        ),
     )
     if request_result["absent_labels"]:
         # This means that Codecov already calculated everything for us


### PR DESCRIPTION
When running ATS locally, it wasn't logging out the errors returned by the API