### PR TITLE
feat: add envvar for static analysis token

### DIFF
--- a/codecov_cli/commands/labelanalysis.py
+++ b/codecov_cli/commands/labelanalysis.py
@@ -21,6 +21,7 @@ logger = logging.getLogger("codecovcli")
 @click.option(
     "--token",
     required=True,
+    envvar="CODECOV_STATIC_TOKEN",
     help="The static analysis token (NOT the same token as upload)",
 )
 @click.option(

--- a/codecov_cli/commands/staticanalysis.py
+++ b/codecov_cli/commands/staticanalysis.py
@@ -38,7 +38,12 @@ logger = logging.getLogger("codecovcli")
     multiple=True,
     default=[],
 )
-@click.option("--token")
+@click.option(
+    "--token",
+    required=True,
+    envvar="CODECOV_STATIC_TOKEN",
+    help="The static analysis token (NOT the same token as upload)",
+)
 @click.pass_context
 def static_analysis(
     ctx,


### PR DESCRIPTION
To make it easier for users to onboard ATS the CLI will look for the value of
static analysis token in the envvar CODECOV_STATIC_TOKEN.

This is similar to what we have for the upload token.

closes codecov/engineering-team#192