### PR TITLE
feat: validate commit SHAs

### DIFF
--- a/codecov_cli/commands/labelanalysis.py
+++ b/codecov_cli/commands/labelanalysis.py
@@ -8,6 +8,7 @@ import requests
 
 from codecov_cli.fallbacks import CodecovOption, FallbackFieldEnum
 from codecov_cli.helpers.config import CODECOV_API_URL
+from codecov_cli.helpers.validators import validate_commit_sha
 from codecov_cli.runners import get_runner
 from codecov_cli.runners.types import (
     LabelAnalysisRequestResult,
@@ -30,6 +31,7 @@ logger = logging.getLogger("codecovcli")
     help="Commit SHA (with 40 chars)",
     cls=CodecovOption,
     fallback_field=FallbackFieldEnum.commit_sha,
+    callback=validate_commit_sha,
     required=True,
 )
 @click.option(
@@ -37,6 +39,7 @@ logger = logging.getLogger("codecovcli")
     "base_commit_sha",
     help="Commit SHA (with 40 chars)",
     cls=CodecovOption,
+    callback=validate_commit_sha,
     required=True,
 )
 @click.option(

--- a/codecov_cli/commands/staticanalysis.py
+++ b/codecov_cli/commands/staticanalysis.py
@@ -6,6 +6,7 @@ import typing
 import click
 
 from codecov_cli.fallbacks import CodecovOption, FallbackFieldEnum
+from codecov_cli.helpers.validators import validate_commit_sha
 from codecov_cli.services.staticanalysis import run_analysis_entrypoint
 
 logger = logging.getLogger("codecovcli")
@@ -29,6 +30,7 @@ logger = logging.getLogger("codecovcli")
     help="Commit SHA (with 40 chars)",
     cls=CodecovOption,
     fallback_field=FallbackFieldEnum.commit_sha,
+    callback=validate_commit_sha,
     required=True,
 )
 @click.option(

--- a/codecov_cli/helpers/validators.py
+++ b/codecov_cli/helpers/validators.py
@@ -1,0 +1,13 @@
+import re
+
+import click
+
+
+def validate_commit_sha(ctx, param, value):
+    if value == "" or value is None:
+        raise click.MissingParameter()
+    if len(value) < 40:
+        raise click.BadParameter("Use the full commit SHA")
+    if not re.match(r"[0-9a-f]{40}", value):
+        raise click.BadParameter("Commit SHA doesn't match SHA1 regex")
+    return value

--- a/tests/commands/test_invoke_labelanalysis.py
+++ b/tests/commands/test_invoke_labelanalysis.py
@@ -50,6 +50,8 @@ def get_labelanalysis_deps(mocker):
         "collected_labels": collected_labels,
     }
 
+FAKE_BASE_SHA="0111111111111111111111111111111111111110"
+
 
 class TestLabelAnalysisNotInvoke(object):
     def test_potentially_calculate_labels_recalculate(self):
@@ -156,8 +158,8 @@ class TestLabelAnalysisCommand(object):
             [
                 "label-analysis",
                 "--token=STATIC_TOKEN",
-                "--base-sha=commit-sha",
-                "--head-sha=commit-sha",
+                "--base-sha=1111111111111111111111111111111111111111",
+                "--head-sha=1111111111111111111111111111111111111111",
             ],
             obj={},
         )
@@ -205,7 +207,7 @@ class TestLabelAnalysisCommand(object):
             cli_runner = CliRunner()
             result = cli_runner.invoke(
                 cli,
-                ["label-analysis", "--token=STATIC_TOKEN", "--base-sha=BASE_SHA"],
+                ["label-analysis", "--token=STATIC_TOKEN", f"--base-sha={FAKE_BASE_SHA}"],
                 obj={},
             )
             assert result.exit_code == 0
@@ -256,7 +258,7 @@ class TestLabelAnalysisCommand(object):
                 [
                     "label-analysis",
                     "--token=STATIC_TOKEN",
-                    "--base-sha=BASE_SHA",
+                    f"--base-sha={FAKE_BASE_SHA}",
                     "--dry-run",
                 ],
                 obj={},
@@ -306,7 +308,7 @@ class TestLabelAnalysisCommand(object):
             cli_runner = CliRunner()
             result = cli_runner.invoke(
                 cli,
-                ["label-analysis", "--token=STATIC_TOKEN", "--base-sha=BASE_SHA"],
+                ["label-analysis", "--token=STATIC_TOKEN", f"--base-sha={FAKE_BASE_SHA}"],
                 obj={},
             )
             mock_get_runner.assert_called()
@@ -343,7 +345,7 @@ class TestLabelAnalysisCommand(object):
                 [
                     "label-analysis",
                     "--token=STATIC_TOKEN",
-                    "--base-sha=BASE_SHA",
+                    f"--base-sha={FAKE_BASE_SHA}",
                     "--dry-run",
                 ],
                 obj={},
@@ -394,7 +396,7 @@ class TestLabelAnalysisCommand(object):
             cli_runner = CliRunner()
             result = cli_runner.invoke(
                 cli,
-                ["label-analysis", "--token=STATIC_TOKEN", "--base-sha=BASE_SHA"],
+                ["label-analysis", "--token=STATIC_TOKEN", f"--base-sha={FAKE_BASE_SHA}"],
                 obj={},
             )
             mock_get_runner.assert_called()
@@ -447,7 +449,7 @@ class TestLabelAnalysisCommand(object):
                 [
                     "label-analysis",
                     "--token=STATIC_TOKEN",
-                    "--base-sha=BASE_SHA",
+                    f"--base-sha={FAKE_BASE_SHA}",
                     "--max-wait-time=5",
                 ],
                 obj={},
@@ -504,7 +506,7 @@ class TestLabelAnalysisCommand(object):
             cli_runner = CliRunner()
             result = cli_runner.invoke(
                 cli,
-                ["label-analysis", "--token=STATIC_TOKEN", "--base-sha=BASE_SHA"],
+                ["label-analysis", "--token=STATIC_TOKEN", f"--base-sha={FAKE_BASE_SHA}"],
                 obj={},
             )
             assert result.exit_code == 0

--- a/tests/factory.py
+++ b/tests/factory.py
@@ -15,7 +15,7 @@ class FakeProvider(CIAdapterBase):
             FallbackFieldEnum.branch: "BUILD_BRANCH",
             FallbackFieldEnum.build_code: "BUILD_CODE",
             FallbackFieldEnum.build_url: "BUILD_URL",
-            FallbackFieldEnum.commit_sha: "COMMIT_SHA",
+            FallbackFieldEnum.commit_sha: "1111111111111111111111111111111111111111",
             FallbackFieldEnum.slug: "REPO_SLUG",
             FallbackFieldEnum.service: "FAKE_PROVIDER",
             FallbackFieldEnum.pull_request_number: "PR_NUMBER",

--- a/tests/helpers/test_validators.py
+++ b/tests/helpers/test_validators.py
@@ -1,0 +1,30 @@
+from unittest.mock import MagicMock
+
+import click
+import pytest
+
+from codecov_cli.helpers.validators import validate_commit_sha
+
+
+@pytest.mark.parametrize(
+    "input,should_raise",
+    [
+        (
+            None,
+            True,
+        ),
+        (
+            "",
+            True,
+        ),
+        ("f39802d4", True),
+        ("!39802d4d87---de18968d1753dd4a6402866  7", True),
+        ("f39802d4d87508de18968d1753dd4a64028662b7", False),
+    ],
+)
+def test_commit_validator(input, should_raise):
+    if should_raise:
+        with pytest.raises(click.BadParameter):
+            validate_commit_sha(MagicMock(), "commit_sha", input)
+    else:
+        assert validate_commit_sha(MagicMock(), "commit_sha", input) == input


### PR DESCRIPTION
This was motivated by the fact that api returns 404 if your label-analysis request
doesn't include a `base_commit` or a `head_commit`. I don't mean the key must be there,
the value needs to be an accurate value, or it will return a puzzling 404 "Not Found".

That is terrible user experience, and even I needed quite some time to figure it out.
So the best thing (I think) is cutting the evil in its root and making sure the user
gives us a valid SHA.

These changes introduce `validate_commit_sha` to `static-analysis` and `label-analysis` commands.
They make sure the user gives us a string that is 40 chars long and consists of only letters and
numbers. So should at least look like a SHA1 string.