### PR TITLE
renaming upload-completion command to send-notifications

### DIFF
--- a/codecov_cli/commands/send_notifications.py
+++ b/codecov_cli/commands/send_notifications.py
@@ -15,7 +15,7 @@ logger = logging.getLogger("codecovcli")
 @click.command()
 @global_options
 @click.pass_context
-def upload_completion(
+def send_notifications(
     ctx,
     commit_sha: str,
     slug: typing.Optional[str],
@@ -25,7 +25,7 @@ def upload_completion(
 ):
     enterprise_url = ctx.obj.get("enterprise_url")
     logger.debug(
-        "Completing upload process",
+        "Sending notifications process has started",
         extra=dict(
             extra_log_attributes=dict(
                 commit_sha=commit_sha,

--- a/codecov_cli/main.py
+++ b/codecov_cli/main.py
@@ -11,9 +11,9 @@ from codecov_cli.commands.empty_upload import empty_upload
 from codecov_cli.commands.get_report_results import get_report_results
 from codecov_cli.commands.labelanalysis import label_analysis
 from codecov_cli.commands.report import create_report
+from codecov_cli.commands.send_notifications import send_notifications
 from codecov_cli.commands.staticanalysis import static_analysis
 from codecov_cli.commands.upload import do_upload
-from codecov_cli.commands.upload_completion import upload_completion
 from codecov_cli.commands.upload_process import upload_process
 from codecov_cli.helpers.ci_adapters import get_ci_adapter, get_ci_providers_list
 from codecov_cli.helpers.config import load_cli_config
@@ -70,7 +70,7 @@ cli.add_command(label_analysis)
 cli.add_command(static_analysis)
 cli.add_command(empty_upload)
 cli.add_command(upload_process)
-cli.add_command(upload_completion)
+cli.add_command(send_notifications)
 
 
 def run():

--- a/tests/test_codecov_cli.py
+++ b/tests/test_codecov_cli.py
@@ -11,7 +11,7 @@ def test_existing_commands():
         "get-report-results",
         "label-analysis",
         "pr-base-picking",
+        "send-notifications",
         "static-analysis",
-        "upload-completion",
         "upload-process",
     ]


### PR DESCRIPTION
renaming upload-completion command to send-notifications, to follow the format of other cli commands
and to give it a more descriptive name. This command can be used whenever a user wants to trigger notifications in cases where no reports where uploaded, or didnt receive notifications for whatever reason. So it makes sense to rename it to be more notifications related than uploads 
We didn't receive any logs for the task that gets triggered except from our repos so it's safe to rename it