### PR TITLE
use raw ref for PR branch to avoid confusion bw upstream and fork

### DIFF
--- a/codecov_cli/helpers/ci_adapters/github_actions.py
+++ b/codecov_cli/helpers/ci_adapters/github_actions.py
@@ -66,22 +66,11 @@ class GithubActionsCIAdapter(CIAdapterBase):
         return os.getenv("GITHUB_REPOSITORY")
 
     def _get_branch(self):
-        branch = os.getenv("GITHUB_HEAD_REF")
-        if branch:
-            return branch
-
-        branch_ref = os.getenv("GITHUB_REF")
-
-        if not branch_ref:
-            return None
-
-        match = re.search(r"refs/heads/(.*)", branch_ref)
-
-        if match is None:
-            return None
-
-        branch = match.group(1)
-        return branch or None
+        trigger_name = os.getenv("GITHUB_EVENT_NAME")
+        if trigger_name == "pull_request" or trigger_name == "pull_request_target":
+            return os.getenv("GITHUB_REF")
+        else:
+            return os.getenv("GITHUB_REF_NAME")
 
     def _get_service(self):
         return "github-actions"

--- a/tests/ci_adapters/test_ghactions.py
+++ b/tests/ci_adapters/test_ghactions.py
@@ -7,6 +7,7 @@ from codecov_cli.fallbacks import FallbackFieldEnum
 from codecov_cli.helpers.ci_adapters import GithubActionsCIAdapter
 
 
+# https://docs.github.com/en/actions/learn-github-actions/variables
 class GithubActionsEnvEnum(str, Enum):
     GITHUB_SHA = "GITHUB_SHA"
     GITHUB_SERVER_URL = "GITHUB_SERVER_URL"
@@ -16,6 +17,8 @@ class GithubActionsEnvEnum(str, Enum):
     GITHUB_REF = "GITHUB_REF"
     GITHUB_REPOSITORY = "GITHUB_REPOSITORY"
     GITHUB_ACTIONS = "GITHUB_ACTIONS"
+    GITHUB_REF_NAME = "GITHUB_REF_NAME"
+    GITHUB_EVENT_NAME = "GITHUB_EVENT_NAME"
 
 
 class TestGithubActions(object):
@@ -203,10 +206,21 @@ class TestGithubActions(object):
         "env_dict,expected",
         [
             ({}, None),
-            ({GithubActionsEnvEnum.GITHUB_HEAD_REF: "random"}, "random"),
-            ({GithubActionsEnvEnum.GITHUB_REF: r"doesn't_match"}, None),
-            ({GithubActionsEnvEnum.GITHUB_REF: r"refs/heads/"}, None),
-            ({GithubActionsEnvEnum.GITHUB_REF: r"refs/heads/abc"}, "abc"),
+            (
+                {
+                    GithubActionsEnvEnum.GITHUB_EVENT_NAME: "pull_request",
+                    GithubActionsEnvEnum.GITHUB_REF: "refs/pulls/13/merge",
+                },
+                "refs/pulls/13/merge",
+            ),
+            (
+                {
+                    GithubActionsEnvEnum.GITHUB_EVENT_NAME: "pull_request_target",
+                    GithubActionsEnvEnum.GITHUB_REF: "refs/pulls/13/merge",
+                },
+                "refs/pulls/13/merge",
+            ),
+            ({GithubActionsEnvEnum.GITHUB_REF_NAME: "my-feature"}, "my-feature"),
         ],
     )
     def test_branch(self, env_dict, expected, mocker):


### PR DESCRIPTION
same as https://github.com/codecov/uploader/pull/1132 but for `codecovcli`

when we upload a report for CI in a PR, we associate the report with the destination repo but we take the branch name from the source repo. so if i make a PR from my fork's `main` branch to an upstream repo's `main` branch, we upload the coverage report for the upstream repo's `main` branch and update the coverage with junk from my un-merged PR

this PR instead will upload `refs/pull/#/merge` as the branch for PRs. it's slightly less nice for same-repo PRs because in order to populate coverage for your feature branches you'll need CI running on push as well as PR, but avoids invalidating coverage for projects that use a super common fork/merge workflow

docs on the environment variables used here: https://docs.github.com/en/actions/learn-github-actions/variables