### PR TITLE
use older ubuntu runner to have wider support

### DIFF
--- a/.github/workflows/release_flow.yml
+++ b/.github/workflows/release_flow.yml
@@ -42,7 +42,7 @@ jobs:
       fail-fast: true
       matrix:
         include:
-          - os: macos-latest
+          - os: macos-11
             TARGET: macos
             CMD_BUILD: >
               STATICCODECOV_LIB_PATH=$(find build/ -maxdepth 1 -type d -name 'lib.*' -print -quit | xargs -I {} sh -c "find {} -type f -name 'staticcodecov*' -print -quit | sed 's|^./||'") &&
@@ -50,7 +50,7 @@ jobs:
               mv dist/main dist/codecovcli_macos
             OUT_FILE_NAME: codecovcli_macos
             ASSET_MIME: application/octet-stream
-          - os: ubuntu-latest
+          - os: ubuntu-20.04
             TARGET: ubuntu
             CMD_BUILD: >
               STATICCODECOV_LIB_PATH=$(find build/ -maxdepth 1 -type d -name 'lib.*' -print -quit | xargs -I {} sh -c "find {} -type f -name 'staticcodecov*' -print -quit | sed 's|^./||'") &&
@@ -81,6 +81,10 @@ jobs:
       run: pip install pyinstaller
     - name: Build with pyinstaller for ${{matrix.TARGET}}
       run: ${{matrix.CMD_BUILD}}
+    - name: Upload a Build Artifact
+      uses: actions/upload-artifact@v3.1.2
+      with:
+        path: ./dist/${{ matrix.OUT_FILE_NAME }}
     - name: Upload Release Asset
       id: upload-release-asset
       uses: svenstaro/upload-release-action@v2

--- a/.github/workflows/release_flow.yml
+++ b/.github/workflows/release_flow.yml
@@ -42,7 +42,7 @@ jobs:
       fail-fast: true
       matrix:
         include:
-          - os: macos-11
+          - os: macos-latest
             TARGET: macos
             CMD_BUILD: >
               STATICCODECOV_LIB_PATH=$(find build/ -maxdepth 1 -type d -name 'lib.*' -print -quit | xargs -I {} sh -c "find {} -type f -name 'staticcodecov*' -print -quit | sed 's|^./||'") &&


### PR DESCRIPTION
The current binary would refuse to run in debian buster and bullseye , the reason is that the glibc used is too new.

changing runner to an older one can extend the supported platform, as is documented in `pyinstaller` doc.

https://pyinstaller.org/en/v5.13.1/usage.html#making-gnu-linux-apps-forward-compatible

Upload a Build Artifact is optionally, it could be useful when debugging ci, I can remove it if you want.

This is the binary I got from build, you can check it from https://github.com/LeoQuote/codecov-cli/actions/runs/6002025929 or download it -> 
[artifact.zip](https://github.com/codecov/codecov-cli/files/12456229/artifact.zip)

I intended to switch macos build in older runner but it seems not successful, I'll leave it to someone more familliar with macos.