### PR TITLE
Change encoding of open in _get_file_fixes to utf8

### DIFF
--- a/codecov_cli/services/upload/upload_collector.py
+++ b/codecov_cli/services/upload/upload_collector.py
@@ -106,7 +106,7 @@ class UploadCollector(object):
         fixed_lines_with_reason = set()
         eof = None
 
-        with open(filename, "r") as f:
+        with open(filename, "r", encoding="utf8") as f:
             for lineno, line_content in enumerate(f):
                 if any(
                     pattern.match(line_content)


### PR DESCRIPTION
This is causing issues where files fail to open because the call is using the wrong encoding