### PR TITLE
fix: JS analyser do-statement

### DIFF
--- a/codecov_cli/services/staticanalysis/analyzers/javascript_es6/node_wrappers.py
+++ b/codecov_cli/services/staticanalysis/analyzers/javascript_es6/node_wrappers.py
@@ -63,9 +63,9 @@ class NodeVisitor(object):
             if node.type == "do_statement":
                 do_statement_body = node.child_by_field_name("body")
                 if do_statement_body.type == "statement_block":
-                    first_statement = do_statement_body.children[1]
+                    do_statement_body = do_statement_body.children[1]
                 elif do_statement_body.type == "expression_statement":
-                    first_statement = do_statement_body.children[0]
+                    do_statement_body = do_statement_body.children[0]
                 self.analyzer.line_surety_ancestorship[
-                    first_statement.start_point[0] + 1
+                    do_statement_body.start_point[0] + 1
                 ] = current_line_number

--- a/samples/inputs/sample_004.js
+++ b/samples/inputs/sample_004.js
@@ -59,3 +59,7 @@ do {
 do
   console.log("The value of i is: " + i);
 while (i < 5);
+
+do 
+  for (j = 0; j < i; j++) console.log('X');
+while (i < 5);

--- a/samples/outputs/sample_004.json
+++ b/samples/outputs/sample_004.json
@@ -1,156 +1,169 @@
 {
     "result": {
         "empty_lines": [
-            2, 8, 10, 12, 16, 19, 22, 24, 33, 35, 37, 52, 58
+            2,
+            8,
+            10,
+            12,
+            16,
+            19,
+            22,
+            24,
+            33,
+            35,
+            37,
+            52,
+            58,
+            62
         ],
         "executable_lines": [],
-        "number_lines": 61,
-        "hash": "94a0d0fa4f21d0e4742395a44017d38c",
+        "number_lines": 65,
+        "hash": "9bbf0e7dd4b918b51e644f4c2c5888df",
         "filename": "samples/inputs/sample_004.js",
         "language": "javascript",
         "import_lines": [],
         "functions": [
             {
-                "identifier": "outerFunction", 
-                "start_line": 1, 
-                "end_line": 7, 
-                "code_hash": "410e3cdac877f4d4d96650fd2bdb7302", 
+                "identifier": "outerFunction",
+                "start_line": 1,
+                "end_line": 7,
+                "code_hash": "410e3cdac877f4d4d96650fd2bdb7302",
                 "complexity_metrics": {
-                    "conditions": 0, 
-                    "mccabe_cyclomatic_complexity": 1, 
-                    "returns": 0, 
+                    "conditions": 0,
+                    "mccabe_cyclomatic_complexity": 1,
+                    "returns": 0,
                     "max_nested_conditional": 0
                 }
-            }, 
+            },
             {
-                "identifier": "outerFunction::innerFunction", 
-                "start_line": 3, 
-                "end_line": 5, 
-                "code_hash": "867352b5697c99ec8bf920eace84b90a", 
+                "identifier": "outerFunction::innerFunction",
+                "start_line": 3,
+                "end_line": 5,
+                "code_hash": "867352b5697c99ec8bf920eace84b90a",
                 "complexity_metrics": {
-                    "conditions": 0, 
-                    "mccabe_cyclomatic_complexity": 1, 
-                    "returns": 0, 
+                    "conditions": 0,
+                    "mccabe_cyclomatic_complexity": 1,
+                    "returns": 0,
                     "max_nested_conditional": 0
                 }
-            }, 
+            },
             {
-                "identifier": "foo", 
-                "start_line": 11, 
-                "end_line": 11, 
+                "identifier": "foo",
+                "start_line": 11,
+                "end_line": 11,
                 "code_hash": "99914b932bd37a50b983c5e7c90ae93b",
                 "complexity_metrics": {
-                    "conditions": 0, 
-                    "mccabe_cyclomatic_complexity": 1, 
-                    "returns": 0, 
-                    "max_nested_conditional": 0
-                    }
-                    }, 
-            {
-                "identifier": "Foo::bar", 
-                "start_line": 14, 
-                "end_line": 14, 
-                "code_hash": "99914b932bd37a50b983c5e7c90ae93b", 
-                "complexity_metrics": {
-                    "conditions": 0, 
-                    "mccabe_cyclomatic_complexity": 1, 
-                    "returns": 0, 
-                    "max_nested_conditional": 0
-                }
-            }, 
-            {
-                "identifier": "Anonymous_18_0", 
-                "start_line": 18, 
-                "end_line": 18, 
-                "code_hash": "8dd5ce440cc0dbf8e9b874e3a9a61951", 
-                "complexity_metrics": {
-                    "conditions": 0, 
-                    "mccabe_cyclomatic_complexity": 1, 
-                    "returns": 1, 
-                    "max_nested_conditional": 0
-                }
-            }, 
-            {
-                "identifier": "foo", 
-                "start_line": 21, 
-                "end_line": 21, 
-                "code_hash": "d858b03b04be75bf6f333641e8ef41a5", 
-                "complexity_metrics": {
-                    "conditions": 0, 
-                    "mccabe_cyclomatic_complexity": 1, 
-                    "returns": 0, 
-                    "max_nested_conditional": 0
-                }
-            }, 
-            {
-                "identifier": "a", 
-                "start_line": 23, 
-                "end_line": 23, 
-                "code_hash": "a9b5caf33c892637947990938210b544", 
-                "complexity_metrics": {
-                    "conditions": 0, 
-                    "mccabe_cyclomatic_complexity": 1, 
-                    "returns": 1, 
-                    "max_nested_conditional": 0
-                }
-            }, 
-            {
-                "identifier": "a::b", 
-                "start_line": 23, 
-                "end_line": 23, 
-                "code_hash": "99914b932bd37a50b983c5e7c90ae93b", 
-                "complexity_metrics": {
-                    "conditions": 0, 
-                    "mccabe_cyclomatic_complexity": 1, 
-                    "returns": 0, 
-                    "max_nested_conditional": 0
-                }
-            }, 
-            {
-                "identifier": "a::c", 
-                "start_line": 23, 
-                "end_line": 23, 
-                "code_hash": "99914b932bd37a50b983c5e7c90ae93b", 
-                "complexity_metrics": {
-                    "conditions": 0, 
-                    "mccabe_cyclomatic_complexity": 1, 
-                    "returns": 0, 
-                    "max_nested_conditional": 0
-                }
-            }, 
-            {
-                "identifier": "Anonymous_26_0", 
-                "start_line": 26, 
-                "end_line": 26, 
-                "code_hash": "99914b932bd37a50b983c5e7c90ae93b", 
-                "complexity_metrics": {
-                    "conditions": 0, 
-                    "mccabe_cyclomatic_complexity": 1, 
-                    "returns": 0, 
-                    "max_nested_conditional": 0
-                }
-            }, 
-            {
-                "identifier": "generateStuff", 
-                "start_line": 27, 
-                "end_line": 31, 
-                "code_hash": "e3ca3f85be0a1ca905c7b5d29c7dc070", 
-                "complexity_metrics": {
-                    "conditions": 0, 
+                    "conditions": 0,
                     "mccabe_cyclomatic_complexity": 1,
-                    "returns": 0, 
+                    "returns": 0,
                     "max_nested_conditional": 0
                 }
-            }, 
+            },
             {
-                "identifier": "Anonymous_34_0", 
-                "start_line": 34, 
-                "end_line": 34, 
-                "code_hash": "99914b932bd37a50b983c5e7c90ae93b", 
+                "identifier": "Foo::bar",
+                "start_line": 14,
+                "end_line": 14,
+                "code_hash": "99914b932bd37a50b983c5e7c90ae93b",
                 "complexity_metrics": {
-                    "conditions": 0, 
-                    "mccabe_cyclomatic_complexity": 1, 
-                    "returns": 0, 
+                    "conditions": 0,
+                    "mccabe_cyclomatic_complexity": 1,
+                    "returns": 0,
+                    "max_nested_conditional": 0
+                }
+            },
+            {
+                "identifier": "Anonymous_18_0",
+                "start_line": 18,
+                "end_line": 18,
+                "code_hash": "8dd5ce440cc0dbf8e9b874e3a9a61951",
+                "complexity_metrics": {
+                    "conditions": 0,
+                    "mccabe_cyclomatic_complexity": 1,
+                    "returns": 1,
+                    "max_nested_conditional": 0
+                }
+            },
+            {
+                "identifier": "foo",
+                "start_line": 21,
+                "end_line": 21,
+                "code_hash": "d858b03b04be75bf6f333641e8ef41a5",
+                "complexity_metrics": {
+                    "conditions": 0,
+                    "mccabe_cyclomatic_complexity": 1,
+                    "returns": 0,
+                    "max_nested_conditional": 0
+                }
+            },
+            {
+                "identifier": "a",
+                "start_line": 23,
+                "end_line": 23,
+                "code_hash": "a9b5caf33c892637947990938210b544",
+                "complexity_metrics": {
+                    "conditions": 0,
+                    "mccabe_cyclomatic_complexity": 1,
+                    "returns": 1,
+                    "max_nested_conditional": 0
+                }
+            },
+            {
+                "identifier": "a::b",
+                "start_line": 23,
+                "end_line": 23,
+                "code_hash": "99914b932bd37a50b983c5e7c90ae93b",
+                "complexity_metrics": {
+                    "conditions": 0,
+                    "mccabe_cyclomatic_complexity": 1,
+                    "returns": 0,
+                    "max_nested_conditional": 0
+                }
+            },
+            {
+                "identifier": "a::c",
+                "start_line": 23,
+                "end_line": 23,
+                "code_hash": "99914b932bd37a50b983c5e7c90ae93b",
+                "complexity_metrics": {
+                    "conditions": 0,
+                    "mccabe_cyclomatic_complexity": 1,
+                    "returns": 0,
+                    "max_nested_conditional": 0
+                }
+            },
+            {
+                "identifier": "Anonymous_26_0",
+                "start_line": 26,
+                "end_line": 26,
+                "code_hash": "99914b932bd37a50b983c5e7c90ae93b",
+                "complexity_metrics": {
+                    "conditions": 0,
+                    "mccabe_cyclomatic_complexity": 1,
+                    "returns": 0,
+                    "max_nested_conditional": 0
+                }
+            },
+            {
+                "identifier": "generateStuff",
+                "start_line": 27,
+                "end_line": 31,
+                "code_hash": "e3ca3f85be0a1ca905c7b5d29c7dc070",
+                "complexity_metrics": {
+                    "conditions": 0,
+                    "mccabe_cyclomatic_complexity": 1,
+                    "returns": 0,
+                    "max_nested_conditional": 0
+                }
+            },
+            {
+                "identifier": "Anonymous_34_0",
+                "start_line": 34,
+                "end_line": 34,
+                "code_hash": "99914b932bd37a50b983c5e7c90ae93b",
+                "complexity_metrics": {
+                    "conditions": 0,
+                    "mccabe_cyclomatic_complexity": 1,
+                    "returns": 0,
                     "max_nested_conditional": 0
                 }
             }
@@ -274,7 +287,6 @@
             ],
             [
                 25,
-             
                 {
                     "extra_connected_lines": [],
                     "len": 7,
@@ -452,9 +464,58 @@
                     "line_surety_ancestorship": 59,
                     "start_column": 2
                 }
+            ],
+            [
+                63,
+                {
+                    "extra_connected_lines": [],
+                    "len": 2,
+                    "line_hash": "0e3216db5adff87bdc42936bb10b179a",
+                    "line_surety_ancestorship": 59,
+                    "start_column": 0
+                }
+            ],
+            [
+                64,
+                {
+                    "extra_connected_lines": [],
+                    "len": 0,
+                    "line_hash": "e771ad5b5cd2eb375d8060f625729c3c",
+                    "line_surety_ancestorship": 64,
+                    "start_column": 2
+                }
+            ],
+            [
+                64,
+                {
+                    "extra_connected_lines": [],
+                    "len": 0,
+                    "line_hash": "08cd31fff69b650cd3964e2b2d5b296e",
+                    "line_surety_ancestorship": 64,
+                    "start_column": 7
+                }
+            ],
+            [
+                64,
+                {
+                    "extra_connected_lines": [],
+                    "len": 0,
+                    "line_hash": "ee9180084115fcd1651ef3f405b7b38e",
+                    "line_surety_ancestorship": 64,
+                    "start_column": 14
+                }
+            ],
+            [
+                64,
+                {
+                    "extra_connected_lines": [],
+                    "len": 0,
+                    "line_hash": "75da31cc74011125307b254ecc730774",
+                    "line_surety_ancestorship": 64,
+                    "start_column": 26
+                }
             ]
         ]
     },
-    "error": null  
+    "error": null
 }
-


### PR DESCRIPTION
We had a call with a customer trying ATS today and they had an error in the JS analyser.
The error was "first_statement referenced before assignment".
This would happen if the first statement in a `do-while` block was not a `statement_block` or `expression_statement`
(I added this case in `sample_004.js` to test it)