### PR TITLE
Handle error reading code files for file fixes due to decoding error

### DIFF
--- a/tests/data/files_to_fix_examples/bad_encoding.go
+++ b/tests/data/files_to_fix_examples/bad_encoding.go
@@ -1,0 +1,26 @@
+
+abc at line 3
+xyz at line 6
+
+// comment at line
+	// another comment
+{
+	asdfadsf?
+}
+{ // hey
+
+}
+func { 
+
+}
+
+func { // fapsodjfpjasdpf jaspdfj 
+
+}
+
+/*
+
+*/
+	/*
+	*/
+


### PR DESCRIPTION
Don't want to crash when there's a decoding error when trying to apply file fixes, want to log warning that file fixes could not be applied to the file and provide information about decoding error.