### PR TITLE
chore: add default config

### DIFF
--- a/codecov_cli/helpers/config.py
+++ b/codecov_cli/helpers/config.py
@@ -15,6 +15,6 @@ def load_cli_config(codecov_yml_path: pathlib.Path):
         with open(codecov_yml_path, "r") as file_stream:
             return yaml.safe_load(file_stream.read())
     logger.warning(
-        f"File {codecov_yml_path} not found, or is not a file. Ignoring config."
+        f"Config file {codecov_yml_path} not found, or is not a file. Ignoring config."
     )
     return None

--- a/codecov_cli/main.py
+++ b/codecov_cli/main.py
@@ -34,6 +34,7 @@ logger = logging.getLogger("codecovcli")
 @click.option(
     "--codecov-yml-path",
     type=click.Path(path_type=pathlib.Path),
+    default=pathlib.Path("codecov.yml"),
 )
 @click.option(
     "--enterprise-url", "--url", "-u", help="Change the upload host (Enterprise use)"
@@ -52,9 +53,7 @@ def cli(
     ctx.help_option_names = ["-h", "--help"]
     ctx.obj["ci_adapter"] = get_ci_adapter(auto_load_params_from)
     ctx.obj["versioning_system"] = get_versioning_system()
-    ctx.obj["codecov_yaml"] = (
-        load_cli_config(codecov_yml_path) if codecov_yml_path else None
-    )
+    ctx.obj["codecov_yaml"] = load_cli_config(codecov_yml_path)
     if ctx.obj["codecov_yaml"] is None:
         logger.debug("No codecov_yaml found")
     ctx.obj["enterprise_url"] = enterprise_url

--- a/tests/commands/test_invoke_labelanalysis.py
+++ b/tests/commands/test_invoke_labelanalysis.py
@@ -50,7 +50,8 @@ def get_labelanalysis_deps(mocker):
         "collected_labels": collected_labels,
     }
 
-FAKE_BASE_SHA="0111111111111111111111111111111111111110"
+
+FAKE_BASE_SHA = "0111111111111111111111111111111111111110"
 
 
 class TestLabelAnalysisNotInvoke(object):
@@ -207,7 +208,11 @@ class TestLabelAnalysisCommand(object):
             cli_runner = CliRunner()
             result = cli_runner.invoke(
                 cli,
-                ["label-analysis", "--token=STATIC_TOKEN", f"--base-sha={FAKE_BASE_SHA}"],
+                [
+                    "label-analysis",
+                    "--token=STATIC_TOKEN",
+                    f"--base-sha={FAKE_BASE_SHA}",
+                ],
                 obj={},
             )
             assert result.exit_code == 0
@@ -308,7 +313,11 @@ class TestLabelAnalysisCommand(object):
             cli_runner = CliRunner()
             result = cli_runner.invoke(
                 cli,
-                ["label-analysis", "--token=STATIC_TOKEN", f"--base-sha={FAKE_BASE_SHA}"],
+                [
+                    "label-analysis",
+                    "--token=STATIC_TOKEN",
+                    f"--base-sha={FAKE_BASE_SHA}",
+                ],
                 obj={},
             )
             mock_get_runner.assert_called()
@@ -396,7 +405,11 @@ class TestLabelAnalysisCommand(object):
             cli_runner = CliRunner()
             result = cli_runner.invoke(
                 cli,
-                ["label-analysis", "--token=STATIC_TOKEN", f"--base-sha={FAKE_BASE_SHA}"],
+                [
+                    "label-analysis",
+                    "--token=STATIC_TOKEN",
+                    f"--base-sha={FAKE_BASE_SHA}",
+                ],
                 obj={},
             )
             mock_get_runner.assert_called()
@@ -506,7 +519,11 @@ class TestLabelAnalysisCommand(object):
             cli_runner = CliRunner()
             result = cli_runner.invoke(
                 cli,
-                ["label-analysis", "--token=STATIC_TOKEN", f"--base-sha={FAKE_BASE_SHA}"],
+                [
+                    "label-analysis",
+                    "--token=STATIC_TOKEN",
+                    f"--base-sha={FAKE_BASE_SHA}",
+                ],
                 obj={},
             )
             assert result.exit_code == 0

--- a/tests/commands/test_invoke_upload_process.py
+++ b/tests/commands/test_invoke_upload_process.py
@@ -63,7 +63,7 @@ def test_upload_process_options(mocker):
         assert result.exit_code == 0
         print(result.output)
 
-        assert result.output.split("\n") == [
+        assert result.output.split("\n")[1:] == [
             "Usage: cli upload-process [OPTIONS]",
             "",
             "Options:",

--- a/tests/services/empty_upload/test_empty_upload.py
+++ b/tests/services/empty_upload/test_empty_upload.py
@@ -76,7 +76,9 @@ def test_empty_upload_200(mocker):
     token = uuid.uuid4()
     runner = CliRunner()
     with runner.isolation() as outstreams:
-        res = empty_upload_logic("commit_sha", "owner/repo", token, "service", None, False)
+        res = empty_upload_logic(
+            "commit_sha", "owner/repo", token, "service", None, False
+        )
     out_bytes = parse_outstreams_into_log_lines(outstreams[0].getvalue())
     assert out_bytes == [
         ("info", "Process Empty Upload complete"),


### PR DESCRIPTION
Adding `codecov.yml` as the default config file the CLI will look for.
It's easy for users to forget to add that in the command, and have it misconfigured and then be like
"why is this not working?".

It's also likely that they'll put the config in the codecov.yml where the rest of they codecov config already lives.

context codecov/engineering-team#397