### PR TITLE
fix: add prettier pytest logging

### DIFF
--- a/codecov_cli/runners/python_standard_runner.py
+++ b/codecov_cli/runners/python_standard_runner.py
@@ -229,7 +229,9 @@ class PythonStandardRunner(LabelAnalysisRunnerInterface):
             label.split("[")[0] if "[" in label else label for label in all_labels
         ]
         command_array = default_options + tests_to_run
-        logger.info("Running tests. (run in verbose mode to get list of tests executed)")
+        logger.info(
+            "Running tests. (run in verbose mode to get list of tests executed)"
+        )
         logger.info(f"  pytest options: \"{' '.join(default_options)}\"")
         logger.info(f"  executed tests: {len(tests_to_run)}")
         logger.debug(

--- a/codecov_cli/runners/python_standard_runner.py
+++ b/codecov_cli/runners/python_standard_runner.py
@@ -229,15 +229,9 @@ class PythonStandardRunner(LabelAnalysisRunnerInterface):
             label.split("[")[0] if "[" in label else label for label in all_labels
         ]
         command_array = default_options + tests_to_run
-        logger.info(
-            "Running tests. (run in verbose mode to get list of tests executed)",
-            extra=dict(
-                extra_log_attributes=dict(
-                    pytest_options=default_options,
-                    executed_tests_count=len(tests_to_run),
-                )
-            ),
-        )
+        logger.info("Running tests. (run in verbose mode to get list of tests executed)")
+        logger.info(f"  pytest options: \"{' '.join(default_options)}\"")
+        logger.info(f"  executed tests: {len(tests_to_run)}")
         logger.debug(
             "List of tests executed",
             extra=dict(extra_log_attributes=dict(executed_tests=tests_to_run)),
@@ -246,5 +240,6 @@ class PythonStandardRunner(LabelAnalysisRunnerInterface):
             output = self._execute_pytest_strict(command_array, capture_output=False)
         else:
             output = self._execute_pytest(command_array, capture_output=False)
-        logger.info("Finished running tests successfully")
+        logger.info(f"Finished running {len(tests_to_run)} tests successfully")
+        logger.info(f"  pytest options: \"{' '.join(default_options)}\"")
         logger.debug(output)


### PR DESCRIPTION
fixes https://github.com/codecov/engineering-team/issues/449

example output
```
info - 2023-09-12 17:21:51,277 -- Received information about tests to run --- {"absent_labels": 6, "present_diff_labels": 0, "global_level_labels": 0, "present_report_labels": 0}
info - 2023-09-12 17:21:51,277 -- Running tests. (run in verbose mode to get list of tests executed)
info - 2023-09-12 17:21:51,277 --   pytest options: "--cov=app --cov-context=test"
info - 2023-09-12 17:21:51,277 --   executed tests: 6
...
info - 2023-09-12 17:21:52,312 -- Finished running 6 tests successfully
info - 2023-09-12 17:21:52,312 --   pytest options: "--cov=app --cov-context=test"
```