### PR TITLE
chore: remove include_curr_dir option

### DIFF
--- a/codecov_cli/runners/python_standard_runner.py
+++ b/codecov_cli/runners/python_standard_runner.py
@@ -53,30 +53,21 @@ class PythonStandardRunnerConfigParams(dict):
         """
         return self.get("strict_mode", False)
 
-    @property
-    def include_curr_dir(self) -> bool:
-        """
-        Only valid for 'strict mode'
-        Account for the difference 'pytest' vs 'python -m pytest'
-        https://docs.pytest.org/en/7.1.x/how-to/usage.html#calling-pytest-through-python-m-pytest
-        """
-        return self.get("include_curr_dir", True)
-
 
 def _include_curr_dir(method):
     """
     Account for the difference 'pytest' vs 'python -m pytest'
     https://docs.pytest.org/en/7.1.x/how-to/usage.html#calling-pytest-through-python-m-pytest
+    Used only in strict_mode
     """
 
     def call_method(self, *args, **kwargs):
-        include_curr_dir = self.params.include_curr_dir
         curr_dir = getcwd()
-        if include_curr_dir:
-            path.append(curr_dir)
+        path.append(curr_dir)
+
         result = method(self, *args, **kwargs)
-        if include_curr_dir:
-            path.remove(curr_dir)
+
+        path.remove(curr_dir)
         return result
 
     return call_method

--- a/tests/runners/test_python_standard_runner.py
+++ b/tests/runners/test_python_standard_runner.py
@@ -49,11 +49,11 @@ class TestPythonStandardRunner(object):
 
     def test_init_with_params(self):
         assert self.runner.params.collect_tests_options == []
-        assert self.runner.params.include_curr_dir == True
+        assert self.runner.params.strict_mode == False
+        assert self.runner.params.coverage_root == "./"
 
         config_params = dict(
             collect_tests_options=["--option=value", "-option"],
-            include_curr_dir=False,
         )
         runner_with_params = PythonStandardRunner(config_params)
         assert runner_with_params.params == config_params
@@ -244,34 +244,6 @@ class TestPythonStandardRunner(object):
     )
     def test_parse_captured_output_error(self, error, expected):
         assert self.runner.parse_captured_output_error(error) == expected
-
-    @patch("codecov_cli.runners.python_standard_runner.getcwd")
-    @patch("codecov_cli.runners.python_standard_runner.path")
-    @patch("codecov_cli.runners.python_standard_runner.get_context")
-    def test_execute_pytest_strict_NOT_include_curr_dir(
-        self, mock_get_context, mock_sys_path, mock_getcwd
-    ):
-        output = "Output in stdout"
-        mock_queue = MagicMock()
-        mock_queue.get.side_effect = [{"output": output}, {"result": ExitCode.OK}]
-        mock_process = MagicMock()
-        mock_process.exitcode = 0
-        mock_get_context.return_value.Queue.return_value = mock_queue
-        mock_get_context.return_value.Process.return_value = mock_process
-
-        config_params = dict(include_curr_dir=False)
-        runner = PythonStandardRunner(config_params=config_params)
-        result = runner._execute_pytest_strict(["--option", "--ignore=batata"])
-        mock_get_context.return_value.Queue.assert_called_with(2)
-        mock_get_context.return_value.Process.assert_called_with(
-            target=_execute_pytest_subprocess,
-            args=[["--option", "--ignore=batata"], mock_queue, pyrunner_stdout, True],
-        )
-        assert mock_queue.get.call_count == 2
-        assert result == output
-        mock_sys_path.append.assert_not_called()
-        mock_getcwd.assert_called()
-        assert result == output
 
     def test_collect_tests(self, mocker):
         collected_test_list = [

--- a/tests/runners/test_runners.py
+++ b/tests/runners/test_runners.py
@@ -24,7 +24,8 @@ class TestRunners(object):
             runner_instance.params.collect_tests_options
             == config_params["collect_tests_options"]
         )
-        assert runner_instance.params.include_curr_dir == True
+        assert runner_instance.params.strict_mode == False
+        assert runner_instance.params.coverage_root == "./"
 
     def test_get_dan_runner_with_params(self):
         config = {


### PR DESCRIPTION
The `include_curr_dir` option is only for strict_mode in python standard runner.
Few people will ever use the strict mode.
Realistically, no one will ever make `include_curr_dir` False because it increases the change
that ATS won't work (and it doesn't work on enough siturations to add one more).

I'm keeping the `strict_mode`, but making the `include_curr_dir` always True.
The default was already True, but now there's no choice.