### PR TITLE
fix: make --dry-run useful

### DIFF
--- a/codecov_cli/commands/labelanalysis.py
+++ b/codecov_cli/commands/labelanalysis.py
@@ -1,7 +1,7 @@
-import json
 import logging
+import pathlib
 import time
-from typing import List
+from typing import List, Optional
 
 import click
 import requests
@@ -55,8 +55,15 @@ logger = logging.getLogger("codecovcli")
 @click.option(
     "--dry-run",
     "dry_run",
-    help="Userful during setup. This will run the label analysis, but will print the result to stdout and terminate instead of calling the runner.process_labelanalysis_result",
+    help='Print list of tests to run and options that need to be added to the test runner as a space-separated list to stdout. Format is ATS_TESTS_TO_RUN="<options> <test_1> <test_2> ... <test_n>"',
     is_flag=True,
+)
+@click.option(
+    "--dry-run-output-path",
+    "dry_run_output_path",
+    help="Prints the dry-run list into dry_run_output_path (in addition to stdout)",
+    type=pathlib.Path,
+    default=None,
 )
 @click.pass_context
 def label_analysis(
@@ -67,6 +74,7 @@ def label_analysis(
     runner_name: str,
     max_wait_time: str,
     dry_run: bool,
+    dry_run_output_path: Optional[pathlib.Path],
 ):
     enterprise_url = ctx.obj.get("enterprise_url")
     logger.debug(
@@ -137,7 +145,12 @@ def label_analysis(
         # Retry it
         eid = _send_labelanalysis_request(payload, url, token_header)
         if eid is None:
-            _fallback_to_collected_labels(requested_labels, runner, dry_run=dry_run)
+            _fallback_to_collected_labels(
+                requested_labels,
+                runner,
+                dry_run=dry_run,
+                dry_run_output_path=dry_run_output_path,
+            )
             return
 
     has_result = False
@@ -157,7 +170,11 @@ def label_analysis(
             if not dry_run:
                 runner.process_labelanalysis_result(request_result)
             else:
-                _dry_run_output(LabelAnalysisRequestResult(request_result), runner)
+                _dry_run_output(
+                    LabelAnalysisRequestResult(request_result),
+                    runner,
+                    dry_run_output_path,
+                )
             return
         if resp_json["state"] == "error":
             logger.error(
@@ -165,7 +182,10 @@ def label_analysis(
                 extra=dict(extra_log_attributes=dict(resp_json=resp_json)),
             )
             _fallback_to_collected_labels(
-                collected_labels=requested_labels, runner=runner, dry_run=dry_run
+                collected_labels=requested_labels,
+                runner=runner,
+                dry_run=dry_run,
+                dry_run_output_path=dry_run_output_path,
             )
             return
         if max_wait_time and (time.monotonic() - start_wait) > max_wait_time:
@@ -173,7 +193,10 @@ def label_analysis(
                 f"Exceeded max waiting time of {max_wait_time} seconds. Running all tests.",
             )
             _fallback_to_collected_labels(
-                collected_labels=requested_labels, runner=runner, dry_run=dry_run
+                collected_labels=requested_labels,
+                runner=runner,
+                dry_run=dry_run,
+                dry_run_output_path=dry_run_output_path,
             )
             return
         logger.info("Waiting more time for result...")
@@ -286,7 +309,9 @@ def _send_labelanalysis_request(payload, url, token_header):
 
 
 def _dry_run_output(
-    result: LabelAnalysisRequestResult, runner: LabelAnalysisRunnerInterface
+    result: LabelAnalysisRequestResult,
+    runner: LabelAnalysisRunnerInterface,
+    dry_run_output_path: Optional[pathlib.Path],
 ):
     labels_to_run = list(
         set(
@@ -296,8 +321,9 @@ def _dry_run_output(
         )
     )
     output = runner.dry_run_runner_options + sorted(labels_to_run)
-    with open("ATS_TESTS_TO_RUN", "w") as fd:
-        fd.write(" ".join(output) + "\n")
+    if dry_run_output_path is not None:
+        with open(dry_run_output_path, "w") as fd:
+            fd.write(" ".join(output) + "\n")
     click.echo(f"ATS_TESTS_TO_RUN=\"{' '.join(output)}\"")
 
 
@@ -306,6 +332,7 @@ def _fallback_to_collected_labels(
     runner: LabelAnalysisRunnerInterface,
     *,
     dry_run: bool = False,
+    dry_run_output_path: Optional[pathlib.Path] = None,
 ) -> dict:
     logger.info("Trying to fallback on collected labels")
     if collected_labels:
@@ -321,6 +348,8 @@ def _fallback_to_collected_labels(
         if not dry_run:
             return runner.process_labelanalysis_result(fake_response)
         else:
-            return _dry_run_output(LabelAnalysisRequestResult(fake_response), runner)
+            return _dry_run_output(
+                LabelAnalysisRequestResult(fake_response), runner, dry_run_output_path
+            )
     logger.error("Cannot fallback to collected labels because no labels were collected")
     raise click.ClickException("Failed to get list of labels to run")

--- a/codecov_cli/runners/python_standard_runner.py
+++ b/codecov_cli/runners/python_standard_runner.py
@@ -53,30 +53,21 @@ class PythonStandardRunnerConfigParams(dict):
         """
         return self.get("strict_mode", False)
 
-    @property
-    def include_curr_dir(self) -> bool:
-        """
-        Only valid for 'strict mode'
-        Account for the difference 'pytest' vs 'python -m pytest'
-        https://docs.pytest.org/en/7.1.x/how-to/usage.html#calling-pytest-through-python-m-pytest
-        """
-        return self.get("include_curr_dir", True)
-
 
 def _include_curr_dir(method):
     """
     Account for the difference 'pytest' vs 'python -m pytest'
     https://docs.pytest.org/en/7.1.x/how-to/usage.html#calling-pytest-through-python-m-pytest
+    Used only in strict_mode
     """
 
     def call_method(self, *args, **kwargs):
-        include_curr_dir = self.params.include_curr_dir
         curr_dir = getcwd()
-        if include_curr_dir:
-            path.append(curr_dir)
+        path.append(curr_dir)
+
         result = method(self, *args, **kwargs)
-        if include_curr_dir:
-            path.remove(curr_dir)
+
+        path.remove(curr_dir)
         return result
 
     return call_method

--- a/codecov_cli/runners/python_standard_runner.py
+++ b/codecov_cli/runners/python_standard_runner.py
@@ -97,6 +97,9 @@ def _execute_pytest_subprocess(
 
 
 class PythonStandardRunner(LabelAnalysisRunnerInterface):
+
+    dry_run_runner_options = ["--cov-context=test"]
+
     def __init__(self, config_params: Optional[dict] = None) -> None:
         super().__init__()
         if config_params is None:

--- a/codecov_cli/runners/types.py
+++ b/codecov_cli/runners/types.py
@@ -1,4 +1,4 @@
-from typing import List
+from typing import Dict, List
 
 
 # This is supposed to be a TypedDict,
@@ -23,7 +23,8 @@ class LabelAnalysisRequestResult(dict):
 
 
 class LabelAnalysisRunnerInterface(object):
-    params = None
+    params: Dict = None
+    dry_run_runner_options: List[str] = []
 
     def collect_tests(self) -> List[str]:
         raise NotImplementedError()

--- a/tests/factory.py
+++ b/tests/factory.py
@@ -75,6 +75,8 @@ class FakeVersioningSystem(VersioningSystemInterface):
 
 
 class FakeRunner(LabelAnalysisRunnerInterface):
+    dry_run_runner_options = ["--labels"]
+
     def __init__(self, collect_tests_response: List[str]) -> None:
         super().__init__()
         self.collect_tests_response = collect_tests_response

--- a/tests/runners/test_python_standard_runner.py
+++ b/tests/runners/test_python_standard_runner.py
@@ -49,11 +49,11 @@ class TestPythonStandardRunner(object):
 
     def test_init_with_params(self):
         assert self.runner.params.collect_tests_options == []
-        assert self.runner.params.include_curr_dir == True
+        assert self.runner.params.strict_mode == False
+        assert self.runner.params.coverage_root == "./"
 
         config_params = dict(
             collect_tests_options=["--option=value", "-option"],
-            include_curr_dir=False,
         )
         runner_with_params = PythonStandardRunner(config_params)
         assert runner_with_params.params == config_params
@@ -244,34 +244,6 @@ class TestPythonStandardRunner(object):
     )
     def test_parse_captured_output_error(self, error, expected):
         assert self.runner.parse_captured_output_error(error) == expected
-
-    @patch("codecov_cli.runners.python_standard_runner.getcwd")
-    @patch("codecov_cli.runners.python_standard_runner.path")
-    @patch("codecov_cli.runners.python_standard_runner.get_context")
-    def test_execute_pytest_strict_NOT_include_curr_dir(
-        self, mock_get_context, mock_sys_path, mock_getcwd
-    ):
-        output = "Output in stdout"
-        mock_queue = MagicMock()
-        mock_queue.get.side_effect = [{"output": output}, {"result": ExitCode.OK}]
-        mock_process = MagicMock()
-        mock_process.exitcode = 0
-        mock_get_context.return_value.Queue.return_value = mock_queue
-        mock_get_context.return_value.Process.return_value = mock_process
-
-        config_params = dict(include_curr_dir=False)
-        runner = PythonStandardRunner(config_params=config_params)
-        result = runner._execute_pytest_strict(["--option", "--ignore=batata"])
-        mock_get_context.return_value.Queue.assert_called_with(2)
-        mock_get_context.return_value.Process.assert_called_with(
-            target=_execute_pytest_subprocess,
-            args=[["--option", "--ignore=batata"], mock_queue, pyrunner_stdout, True],
-        )
-        assert mock_queue.get.call_count == 2
-        assert result == output
-        mock_sys_path.append.assert_not_called()
-        mock_getcwd.assert_called()
-        assert result == output
 
     def test_collect_tests(self, mocker):
         collected_test_list = [

--- a/tests/runners/test_runners.py
+++ b/tests/runners/test_runners.py
@@ -24,7 +24,8 @@ class TestRunners(object):
             runner_instance.params.collect_tests_options
             == config_params["collect_tests_options"]
         )
-        assert runner_instance.params.include_curr_dir == True
+        assert runner_instance.params.strict_mode == False
+        assert runner_instance.params.coverage_root == "./"
 
     def test_get_dan_runner_with_params(self):
         config = {


### PR DESCRIPTION
This makes the --dry-run in label-analysis actually do something useful.
It prints the tests you need to run _with_ the tool options to make ats run correctly.

In the case of pytest this means that it prints `--cov-context=test` (we need this to get labels)
and then the list of labels to run, spearated by spaces.

I couldn't find a way to actually export an ENV variable safely so I'm just printing to stdout
The small problem is that there's other output with it, so I decided to add "ATS_TESTS_TO_RUN="
to make grep-ing easier. Just for good measure throw it in a file as well.

So in thory if you get ATS_TESTS_TO_RUN from your CI you can do
`pytest <YOUR NORMAL OPTIONS> <ATS_TESTS_TO_RUN>` and that should work to run all the ATS tests.

closes codecov/engineering-team#470