### PR TITLE
fix: make max_conditional iterative

### DIFF
--- a/codecov_cli/services/staticanalysis/analyzers/general.py
+++ b/codecov_cli/services/staticanalysis/analyzers/general.py
@@ -22,7 +22,7 @@ class BaseAnalyzer(object):
         Uses BFS to avoid recursion calls (so we don't throw RecursionError)
         """
         nodes_to_visit = deque()
-        nodes_to_visit.append([head, 0])
+        nodes_to_visit.append([head, int(head.type in self.condition_statements)])
         max_nested_depth = 0
 
         while nodes_to_visit:

--- a/samples/inputs/sample_002.py
+++ b/samples/inputs/sample_002.py
@@ -27,3 +27,9 @@ assert a
 c = 0
 while c < 1:
     print("b")
+
+def nested_conditionals(val):
+    if val > 10:
+        if val > 100:
+            if val > 1000:
+                return 'large value'

--- a/samples/outputs/sample_002.json
+++ b/samples/outputs/sample_002.json
@@ -45,10 +45,22 @@
                     "returns": 0,
                     "max_nested_conditional": 0
                 }
+            },
+            {
+                "identifier": "nested_conditionals",
+                "start_line": 31,
+                "end_line": 35,
+                "code_hash": "9ee2ce7f737ad1adf8e8e6be70be534b",
+                "complexity_metrics": {
+                    "conditions": 3,
+                    "max_nested_conditional": 3,
+                    "mccabe_cyclomatic_complexity": 4,
+                    "returns": 1
+                }
             }
         ],
-        "hash": "97be1c2949c8f328b8ba5673eba21a84",
-        "number_lines": 30,
+        "hash": "9fb6bbc43350a18531adfb399f5cc0ae",
+        "number_lines": 35,
         "statements": [
             [
                 9,
@@ -199,6 +211,46 @@
                     "len": 0,
                     "extra_connected_lines": []
                 }
+            ],
+            [
+                32,
+                {
+                    "extra_connected_lines": [],
+                    "len": 3,
+                    "line_hash": "9ee2ce7f737ad1adf8e8e6be70be534b",
+                    "line_surety_ancestorship": null,
+                    "start_column": 4
+                }
+            ],
+            [
+                33,
+                {
+                    "extra_connected_lines": [],
+                    "len": 2,
+                    "line_hash": "3d1fa1be2935c716122a2a63eb0070f3",
+                    "line_surety_ancestorship": 32,
+                    "start_column": 8
+                }
+            ],
+            [
+                34,
+                {
+                    "extra_connected_lines": [],
+                    "len": 1,
+                    "line_hash": "20a6f68248783caeab8abb2ccda43cb3",
+                    "line_surety_ancestorship": 33,
+                    "start_column": 12
+                }
+            ],
+            [
+                35,
+                {
+                    "extra_connected_lines": [],
+                    "len": 0,
+                    "line_hash": "6c92ccd39eaa87eb873f2de3e475db82",
+                    "line_surety_ancestorship": 34,
+                    "start_column": 16
+                }
             ]
         ],
         "definition_lines": [
@@ -213,6 +265,10 @@
             [
                 17,
                 1
+            ],
+            [
+                31,
+                4
             ]
         ],
         "import_lines": [


### PR DESCRIPTION
context: codecov/codecov-cli#243

User ran into `RecursionError: maximum recursion depth exceeded` running
`_get_max_nested_conditional`.

By removing the recursion from the function we hopefully fix this issue.
So now it's using text-book definition of BFS to go about finding the max depth.

Notice we do have to go through all nodes of the function because we don't know if a node that is not
of type conditional doesn't have another conditional inside of it (think block nodes, for example).
And we only increase the level when we pass through one conditional, not when we go to the next child.

close codecov/codecov-cli#243