### PR TITLE
fix: surface processing errors

### DIFF
--- a/codecov_cli/commands/labelanalysis.py
+++ b/codecov_cli/commands/labelanalysis.py
@@ -164,8 +164,16 @@ def label_analysis(
         )
         resp_json = resp_data.json()
         if resp_json["state"] == "finished":
+            logger.info(
+                "Received list of tests from Codecov",
+                extra=dict(
+                    extra_log_attributes=dict(
+                        processing_errors=resp_json.get("errors", [])
+                    )
+                ),
+            )
             request_result = _potentially_calculate_absent_labels(
-                resp_data.json()["result"], requested_labels
+                resp_json["result"], requested_labels
             )
             if not dry_run:
                 runner.process_labelanalysis_result(request_result)
@@ -206,14 +214,6 @@ def label_analysis(
 def _potentially_calculate_absent_labels(
     request_result, requested_labels
 ) -> LabelAnalysisRequestResult:
-    logger.info(
-        "Received list of tests from Codecov",
-        extra=dict(
-            extra_log_attributes=dict(
-                processing_errors=request_result.get("errors", [])
-            )
-        ),
-    )
     if request_result["absent_labels"]:
         # This means that Codecov already calculated everything for us
         final_result = LabelAnalysisRequestResult(request_result)


### PR DESCRIPTION
https://github.com/codecov/worker/pull/99 had the unwanted and overlooked effect of slightly changing the format
of the response from Codecov label-analysis.

Before the "errors" key was inside the "result" (it shouldn't be)
So the CLI is not surfacing these errors anymore.

These changes fix that and move the log line to a more logical position.