### PR TITLE
fix: better handle errors in static analysis

### DIFF
--- a/codecov_cli/services/staticanalysis/analyzers/__init__.py
+++ b/codecov_cli/services/staticanalysis/analyzers/__init__.py
@@ -1,9 +1,12 @@
 from codecov_cli.services.staticanalysis.analyzers.general import BaseAnalyzer
 from codecov_cli.services.staticanalysis.analyzers.javascript_es6 import ES6Analyzer
 from codecov_cli.services.staticanalysis.analyzers.python import PythonAnalyzer
+from codecov_cli.services.staticanalysis.types import FileAnalysisRequest
 
 
-def get_best_analyzer(filename, actual_code) -> BaseAnalyzer:
+def get_best_analyzer(
+    filename: FileAnalysisRequest, actual_code: bytes
+) -> BaseAnalyzer:
     if filename.actual_filepath.suffix == ".py":
         return PythonAnalyzer(filename, actual_code)
     if filename.actual_filepath.suffix == ".js":

--- a/codecov_cli/services/staticanalysis/analyzers/python/__init__.py
+++ b/codecov_cli/services/staticanalysis/analyzers/python/__init__.py
@@ -7,6 +7,7 @@ from codecov_cli.services.staticanalysis.analyzers.general import BaseAnalyzer
 from codecov_cli.services.staticanalysis.analyzers.python.node_wrappers import (
     NodeVisitor,
 )
+from codecov_cli.services.staticanalysis.types import FileAnalysisRequest
 
 _function_query_str = """
 (function_definition
@@ -52,14 +53,16 @@ class PythonAnalyzer(BaseAnalyzer):
     ]
     wrappers = ["class_definition", "function_definition"]
 
-    def __init__(self, path, actual_code, **options):
+    def __init__(
+        self, file_analysis_request: FileAnalysisRequest, actual_code: bytes, **options
+    ):
         self.actual_code = actual_code
         self.lines = self.actual_code.split(b"\n")
         self.statements = []
         self.import_lines = set()
         self.definitions_lines = set()
         self.functions = []
-        self.path = path.result_filename
+        self.path = file_analysis_request.result_filename
         self.PY_LANGUAGE = Language(staticcodecov_languages.__file__, "python")
         self.parser = Parser()
         self.parser.set_language(self.PY_LANGUAGE)

--- a/codecov_cli/services/staticanalysis/analyzers/python/node_wrappers.py
+++ b/codecov_cli/services/staticanalysis/analyzers/python/node_wrappers.py
@@ -1,3 +1,8 @@
+from tree_sitter import Node
+
+from codecov_cli.services.staticanalysis.exceptions import AnalysisError
+
+
 class NodeVisitor(object):
     def __init__(self, analyzer):
         self.analyzer = analyzer
@@ -5,12 +10,12 @@ class NodeVisitor(object):
     def start_visit(self, node):
         self.visit(node)
 
-    def visit(self, node):
+    def visit(self, node: Node):
         self.do_visit(node)
         for c in node.children:
             self.visit(c)
 
-    def _is_function_docstring(self, node):
+    def _is_function_docstring(self, node: Node):
         """Skips docstrings for funtions, such as this one.
         Pytest doesn't include them in the report, so I don't think we should either,
         at least for now.
@@ -39,7 +44,7 @@ class NodeVisitor(object):
             and is_in_function_context
         )
 
-    def _get_previous_sibling_that_is_not_comment_not_func_docstring(self, node):
+    def _get_previous_sibling_that_is_not_comment_not_func_docstring(self, node: Node):
         curr = node.prev_named_sibling
         while curr is not None and (
             curr.type == "comment" or self._is_function_docstring(curr)
@@ -47,7 +52,7 @@ class NodeVisitor(object):
             curr = curr.prev_named_sibling
         return curr
 
-    def do_visit(self, node):
+    def do_visit(self, node: Node):
         if node.is_named:
             current_line_number = node.start_point[0] + 1
             if node.type in (
@@ -84,17 +89,29 @@ class NodeVisitor(object):
                     }
                 )
             if node.type in ("if_statement", "elif_clause"):
+                # Some of the children of a node have a field_name associated to them
+                # In the case of an if and elif, "consequence" is the code that is executed in that branch of code
                 first_if_statement = node.child_by_field_name("consequence")
-                if first_if_statement.type == "block":
-                    first_if_statement = first_if_statement.children[0]
+                try:
+                    if first_if_statement.type == "block":
+                        first_if_statement = first_if_statement.children[0]  # BUG
+                except IndexError:
+                    raise AnalysisError(
+                        f"if_statement consequence is empty block @ {self.analyzer.path}:{first_if_statement.start_point[0] + 1}, column {first_if_statement.start_point[1]}"
+                    )
                 self.analyzer.line_surety_ancestorship[
                     first_if_statement.start_point[0] + 1
                 ] = current_line_number
             if node.type in ("for_statement", "while_statement"):
-                first_if_statement = node.child_by_field_name("body")
-                if first_if_statement.type == "block":
-                    first_if_statement = first_if_statement.children[0]
+                first_loop_statement = node.child_by_field_name("body")
+                try:
+                    if first_loop_statement.type == "block":
+                        first_loop_statement = first_loop_statement.children[0]
+                except IndexError:
+                    raise AnalysisError(
+                        f"loop_statement body is empty block @ {self.analyzer.path}:{first_loop_statement.start_point[0] + 1}, column {first_loop_statement.start_point[1]}"
+                    )
                 self.analyzer.line_surety_ancestorship[
-                    first_if_statement.start_point[0] + 1
+                    first_loop_statement.start_point[0] + 1
                 ] = current_line_number
                 pass

--- a/tests/services/static_analysis/languages/python/test_node_wrappers_malformed_code.py
+++ b/tests/services/static_analysis/languages/python/test_node_wrappers_malformed_code.py
@@ -1,0 +1,65 @@
+import pathlib
+
+import pytest
+from tree_sitter import Node
+
+from codecov_cli.services.staticanalysis.analyzers.python import PythonAnalyzer
+from codecov_cli.services.staticanalysis.analyzers.python.node_wrappers import (
+    NodeVisitor,
+)
+from codecov_cli.services.staticanalysis.exceptions import AnalysisError
+from codecov_cli.services.staticanalysis.types import FileAnalysisRequest
+
+
+class TestMalformedIfStatements(object):
+    def test_if_empty_block_raises_analysis_error(self):
+        analysis_request = FileAnalysisRequest(
+            actual_filepath=pathlib.Path("test_file"), result_filename="test_file"
+        )
+        # Code for an empty IF. NOT valid python code
+        actual_code = b'x = 10\nif x == "batata":\n\n'
+        python_analyser = PythonAnalyzer(analysis_request, actual_code=actual_code)
+        # Parse the code snippet and get the if_statement node
+        tree = python_analyser.parser.parse(actual_code)
+        root = tree.root_node
+        assert root.type == "module"
+        assert root.child_count == 2
+        if_statement_node = root.children[1]
+        assert if_statement_node.type == "if_statement"
+        # Make sure it is indeed an empty if_statement
+        if_body = if_statement_node.child_by_field_name("consequence")
+        assert if_body.type == "block"
+        assert if_body.child_count == 0
+        visitor = NodeVisitor(python_analyser)
+        with pytest.raises(AnalysisError) as exp:
+            visitor.do_visit(if_statement_node)
+        assert (
+            str(exp.value)
+            == "if_statement consequence is empty block @ test_file:2, column 17"
+        )
+
+    def test_for_empty_block_raises_analysis_error(self):
+        analysis_request = FileAnalysisRequest(
+            actual_filepath=pathlib.Path("test_file"), result_filename="test_file"
+        )
+        # Code for an empty IF. NOT valid python code
+        actual_code = b"for x in range(10):\n\n"
+        python_analyser = PythonAnalyzer(analysis_request, actual_code=actual_code)
+        # Parse the code snippet and get the if_statement node
+        tree = python_analyser.parser.parse(actual_code)
+        root = tree.root_node
+        assert root.type == "module"
+        assert root.child_count == 1
+        for_statement_node = root.children[0]
+        assert for_statement_node.type == "for_statement"
+        # Make sure it is indeed an empty if_statement
+        if_body = for_statement_node.child_by_field_name("body")
+        assert if_body.type == "block"
+        assert if_body.child_count == 0
+        visitor = NodeVisitor(python_analyser)
+        with pytest.raises(AnalysisError) as exp:
+            visitor.do_visit(for_statement_node)
+        assert (
+            str(exp.value)
+            == "loop_statement body is empty block @ test_file:1, column 19"
+        )


### PR DESCRIPTION
This was needed already.
But ultimately inspired by a user tha had the following error:

```
File "codecov_cli/services/staticanalysis/analyzers/python/node_wrappers.py", line 41, in do_visit
    first_if_statement = first_if_statement.children[0]
IndexError: list index out of range
```

Despite my best efforts, I was only able to reproduce this error using invalid Python code
(i.e. an empty `if` statement)

Regardless of what caused this issue in the 1st place, there may be valid reasons
for someone to have malformed code in their repo (depending what the repo is 👀)
So we should be able to still upload _something_ and ignore the failures.

The tricky thing here is that without the static analysis data ATS can't work well.
And we can't be sure that the analyzer doesn't have bugs. I don't think this case in
particular is one of them, but I could be wrong.

So these changes actually are a way to surface processing errors AND ignore the files
that generated them, WHILE also surfacing errors to users. They are surfaced twice.
Ideally users would look at them and let us know if something is not right.

But maybe we should still fail the static analysis step in their CI? 🧐