### PR TITLE
chore: rename PythonStandardRunner

### DIFF
--- a/codecov_cli/commands/labelanalysis.py
+++ b/codecov_cli/commands/labelanalysis.py
@@ -44,7 +44,7 @@ logger = logging.getLogger("codecovcli")
     required=True,
 )
 @click.option(
-    "--runner-name", "--runner", "runner_name", help="Runner to use", default="python"
+    "--runner-name", "--runner", "runner_name", help="Runner to use", default="pytest"
 )
 @click.option(
     "--max-wait-time",

--- a/codecov_cli/runners/__init__.py
+++ b/codecov_cli/runners/__init__.py
@@ -5,7 +5,7 @@ from importlib import import_module
 import click
 
 from codecov_cli.runners.dan_runner import DoAnythingNowRunner
-from codecov_cli.runners.python_standard_runner import PythonStandardRunner
+from codecov_cli.runners.pytest_standard_runner import PytestStandardRunner
 from codecov_cli.runners.types import LabelAnalysisRunnerInterface
 
 logger = logging.getLogger("codecovcli")
@@ -42,9 +42,17 @@ def _load_runner_from_yaml(plugin_dict: typing.Dict) -> LabelAnalysisRunnerInter
 
 
 def get_runner(cli_config, runner_name) -> LabelAnalysisRunnerInterface:
-    if runner_name == "python":
-        config_params = cli_config.get("runners", {}).get("python", {})
-        return PythonStandardRunner(config_params)
+    if runner_name == "pytest":
+        config_params = cli_config.get("runners", {}).get("pytest", {})
+        # This is for backwards compatibility with versions <= 0.3.4
+        # In which the key for this config was 'python', not 'pytest'
+        if config_params == {}:
+            config_params = cli_config.get("runners", {}).get("python", {})
+            if config_params:
+                logger.warning(
+                    "Using 'python' to configure the PytestStandardRunner is deprecated. Please change to 'pytest'"
+                )
+        return PytestStandardRunner(config_params)
     elif runner_name == "dan":
         config_params = cli_config.get("runners", {}).get("dan", {})
         return DoAnythingNowRunner(config_params)

--- a/codecov_cli/runners/pytest_standard_runner.py
+++ b/codecov_cli/runners/pytest_standard_runner.py
@@ -15,7 +15,7 @@ from codecov_cli.runners.types import (
 logger = logging.getLogger("codecovcli")
 
 
-class PythonStandardRunnerConfigParams(dict):
+class PytestStandardRunnerConfigParams(dict):
     @property
     def collect_tests_options(self) -> List[str]:
         return self.get("collect_tests_options", [])
@@ -38,7 +38,7 @@ class PythonStandardRunnerConfigParams(dict):
         return self.get("coverage_root", "./")
 
 
-class PythonStandardRunner(LabelAnalysisRunnerInterface):
+class PytestStandardRunner(LabelAnalysisRunnerInterface):
 
     dry_run_runner_options = ["--cov-context=test"]
 
@@ -46,7 +46,7 @@ class PythonStandardRunner(LabelAnalysisRunnerInterface):
         super().__init__()
         if config_params is None:
             config_params = {}
-        self.params = PythonStandardRunnerConfigParams(config_params)
+        self.params = PytestStandardRunnerConfigParams(config_params)
 
     def parse_captured_output_error(self, exp: CalledProcessError) -> str:
         result = ""

--- a/tests/runners/test_pytest_standard_runner.py
+++ b/tests/runners/test_pytest_standard_runner.py
@@ -5,14 +5,14 @@ import click
 import pytest
 from pytest import ExitCode
 
-from codecov_cli.runners.python_standard_runner import PythonStandardRunner
-from codecov_cli.runners.python_standard_runner import logger as runner_logger
-from codecov_cli.runners.python_standard_runner import stdout as pyrunner_stdout
+from codecov_cli.runners.pytest_standard_runner import PytestStandardRunner
+from codecov_cli.runners.pytest_standard_runner import logger as runner_logger
+from codecov_cli.runners.pytest_standard_runner import stdout as pyrunner_stdout
 from codecov_cli.runners.types import LabelAnalysisRequestResult
 
 
 class TestPythonStandardRunner(object):
-    runner = PythonStandardRunner()
+    runner = PytestStandardRunner()
 
     def test_init_with_params(self):
         assert self.runner.params.collect_tests_options == []
@@ -21,10 +21,10 @@ class TestPythonStandardRunner(object):
         config_params = dict(
             collect_tests_options=["--option=value", "-option"],
         )
-        runner_with_params = PythonStandardRunner(config_params)
+        runner_with_params = PytestStandardRunner(config_params)
         assert runner_with_params.params == config_params
 
-    @patch("codecov_cli.runners.python_standard_runner.subprocess")
+    @patch("codecov_cli.runners.pytest_standard_runner.subprocess")
     def test_execute_pytest(self, mock_subprocess):
         output = "Output in stdout"
         return_value = MagicMock(stdout=output.encode("utf-8"))
@@ -39,7 +39,7 @@ class TestPythonStandardRunner(object):
         )
         assert result == output
 
-    @patch("codecov_cli.runners.python_standard_runner.subprocess")
+    @patch("codecov_cli.runners.pytest_standard_runner.subprocess")
     def test_execute_pytest_fail_collection(self, mock_subprocess):
         def side_effect(command, *args, **kwargs):
             raise CalledProcessError(
@@ -58,7 +58,7 @@ class TestPythonStandardRunner(object):
             == "Pytest exited with non-zero code 2.\nThis is likely not a problem with label-analysis. Check pytest's output and options.\nPYTEST OUTPUT:\nProcess running up to here...\nSome error occured"
         )
 
-    @patch("codecov_cli.runners.python_standard_runner.subprocess")
+    @patch("codecov_cli.runners.pytest_standard_runner.subprocess")
     def test_execute_pytest_fail_execution(self, mock_subprocess):
         def side_effect(command, *args, **kwargs):
             # In this scenario the regular output AND the stderr message will have been printed
@@ -123,7 +123,7 @@ class TestPythonStandardRunner(object):
             "tests/services/upload/test_upload_service.py::test_do_upload_logic_verbose"
         ]
         mock_execute = mocker.patch.object(
-            PythonStandardRunner,
+            PytestStandardRunner,
             "_execute_pytest",
             return_value="\n".join(collected_test_list),
         )
@@ -138,13 +138,13 @@ class TestPythonStandardRunner(object):
             "tests/services/upload/test_upload_collector.py::test_fix_php_files"
         ]
         mock_execute = mocker.patch.object(
-            PythonStandardRunner,
+            PytestStandardRunner,
             "_execute_pytest",
             return_value="\n".join(collected_test_list),
         )
 
         config_params = dict(collect_tests_options=["--option=value", "-option"])
-        runner_with_params = PythonStandardRunner(config_params)
+        runner_with_params = PytestStandardRunner(config_params)
 
         collected_tests_from_runner = runner_with_params.collect_tests()
         mock_execute.assert_called_with(
@@ -159,7 +159,7 @@ class TestPythonStandardRunner(object):
             "present_diff_labels": ["test_in_diff"],
             "global_level_labels": ["test_global"],
         }
-        mock_execute = mocker.patch.object(PythonStandardRunner, "_execute_pytest")
+        mock_execute = mocker.patch.object(PytestStandardRunner, "_execute_pytest")
 
         self.runner.process_labelanalysis_result(
             LabelAnalysisRequestResult(label_analysis_result)
@@ -185,10 +185,10 @@ class TestPythonStandardRunner(object):
             "present_diff_labels": ["test_in_diff"],
             "global_level_labels": ["test_global"],
         }
-        mock_execute = mocker.patch.object(PythonStandardRunner, "_execute_pytest")
+        mock_execute = mocker.patch.object(PytestStandardRunner, "_execute_pytest")
 
         config_params = dict(coverage_root="coverage_root/")
-        runner_with_params = PythonStandardRunner(config_params)
+        runner_with_params = PytestStandardRunner(config_params)
         runner_with_params.process_labelanalysis_result(
             LabelAnalysisRequestResult(label_analysis_result)
         )
@@ -213,13 +213,13 @@ class TestPythonStandardRunner(object):
             "present_diff_labels": ["test_in_diff"],
             "global_level_labels": ["test_global"],
         }
-        mock_execute = mocker.patch.object(PythonStandardRunner, "_execute_pytest")
+        mock_execute = mocker.patch.object(PytestStandardRunner, "_execute_pytest")
         mock_warning = mocker.patch.object(runner_logger, "warning")
 
         runner_config = {
             "execute_tests_options": ["-s", "--cov-report=xml", "--cov=something"]
         }
-        runner = PythonStandardRunner(runner_config)
+        runner = PytestStandardRunner(runner_config)
         runner.process_labelanalysis_result(
             LabelAnalysisRequestResult(label_analysis_result)
         )
@@ -251,7 +251,7 @@ class TestPythonStandardRunner(object):
             "present_diff_labels": [],
             "global_level_labels": [],
         }
-        mock_execute = mocker.patch.object(PythonStandardRunner, "_execute_pytest")
+        mock_execute = mocker.patch.object(PytestStandardRunner, "_execute_pytest")
 
         self.runner.process_labelanalysis_result(
             LabelAnalysisRequestResult(label_analysis_result)

--- a/tests/runners/test_runners.py
+++ b/tests/runners/test_runners.py
@@ -4,22 +4,34 @@ import pytest
 
 from codecov_cli.runners import _load_runner_from_yaml, get_runner
 from codecov_cli.runners.dan_runner import DoAnythingNowRunner
-from codecov_cli.runners.python_standard_runner import PythonStandardRunner
+from codecov_cli.runners.pytest_standard_runner import PytestStandardRunner
 from tests.factory import FakeRunner
 
 
 class TestRunners(object):
     def test_get_standard_runners(self):
-        assert isinstance(get_runner({}, "python"), PythonStandardRunner)
+        assert isinstance(get_runner({}, "pytest"), PytestStandardRunner)
         assert isinstance(get_runner({}, "dan"), DoAnythingNowRunner)
         # TODO: Extend with other standard runners once we create them (e.g. JS)
 
-    def test_python_standard_runner_with_options(self):
+    def test_pytest_standard_runner_with_options_backwards_compatible(self):
         config_params = dict(
             collect_tests_options=["--option=value", "-option"],
         )
-        runner_instance = get_runner({"runners": {"python": config_params}}, "python")
-        assert isinstance(runner_instance, PythonStandardRunner)
+        runner_instance = get_runner({"runners": {"pytest": config_params}}, "pytest")
+        assert isinstance(runner_instance, PytestStandardRunner)
+        assert (
+            runner_instance.params.collect_tests_options
+            == config_params["collect_tests_options"]
+        )
+        assert runner_instance.params.coverage_root == "./"
+
+    def test_pytest_standard_runner_with_options_backwards_compatible(self):
+        config_params = dict(
+            collect_tests_options=["--option=value", "-option"],
+        )
+        runner_instance = get_runner({"runners": {"python": config_params}}, "pytest")
+        assert isinstance(runner_instance, PytestStandardRunner)
         assert (
             runner_instance.params.collect_tests_options
             == config_params["collect_tests_options"]


### PR DESCRIPTION
This is lower priority, but it has been pointed out to me that `PythonStandardRunner`
is not accurate. There are other test runners available in python after all.

So these changes simple rename it to be `PytestStandardRunner` instead.
Include changes to default options to the `--runner` option and the config key
for the runner. I made that to be backwards compatible tho.