### PR TITLE
fix: Fix VERSION file missing

### DIFF
--- a/codecov_cli/__init__.py
+++ b/codecov_cli/__init__.py
@@ -1,4 +1,9 @@
-with open("VERSION", encoding="utf-8") as f:
+from os import path
+
+here = path.abspath(path.dirname(__file__))
+
+
+with open(path.join(here, "..", "VERSION"), encoding="utf-8") as f:
     version_number = f.readline().strip()
 
 __version__ = version_number


### PR DESCRIPTION
The path for the version file was not currectly setup.
It was looking for VERSION in the current dir (where python was running),
not where the CLI is installed.