### PR TITLE
ref: fix version lookup and package build from source

### DIFF
--- a/codecov_cli/__init__.py
+++ b/codecov_cli/__init__.py
@@ -1,1 +1,4 @@
-__version__ = '0.3.6'
+import importlib.metadata
+
+
+__version__ = importlib.metadata.version('codecov-cli')

--- a/setup.py
+++ b/setup.py
@@ -8,12 +8,9 @@ here = path.abspath(path.dirname(__file__))
 with open(path.join(here, "README.md"), encoding="utf-8") as f:
     long_description = f.read()
 
-with open(path.join(here, "VERSION"), encoding="utf-8") as f:
-    version = f.readline().strip()
-
 setup(
     name="codecov-cli",
-    version=version,
+    version='0.3.6',
     packages=find_packages(exclude=["contrib", "docs", "tests*"]),
     description="Codecov Command Line Interface",
     long_description=long_description,
@@ -34,6 +31,7 @@ setup(
             "codecovcli = codecov_cli.main:run",
         ],
     },
+    python_requires=">=3.8",
     ext_modules=[
         Extension(
             "staticcodecov_languages",


### PR DESCRIPTION
this is the minimum patch to fix building from source

tested with `python -m build`

I also added `python_requires` so that older pythons will get a useful error message if attempting to install an incompatible version