### PR TITLE
fix: Try to fix httpx.PoolTimeout error

### DIFF
--- a/codecov_cli/services/staticanalysis/__init__.py
+++ b/codecov_cli/services/staticanalysis/__init__.py
@@ -103,8 +103,7 @@ async def run_analysis_entrypoint(
             length=len(files_that_need_upload),
             label="Uploading files",
         ) as bar:
-            limits = httpx.Limits(max_keepalive_connections=3, max_connections=5)
-            async with httpx.AsyncClient(limits=limits) as client:
+            async with httpx.AsyncClient() as client:
                 all_tasks = []
                 for el in files_that_need_upload:
                     all_tasks.append(send_single_upload_put(client, all_data, el))


### PR DESCRIPTION
This is an attempt to limit the httpx.PoolTimeout
errors when uploading code.

Fingers crossed the default limits work better for us.
Let it be known that we don't know why the limits were chosen,
so we are essentially winging it at this point.