### PR TITLE
feat: surface label-analysis fallbacks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,8 @@ jobs:
           submodules: true
           fetch-depth: 2
       - uses: actions/setup-python@v3
+        with:
+          python-version: '3.11.x'
       - name: Install CLI
         run: |
           pip install codecov-cli
@@ -87,6 +89,8 @@ jobs:
           submodules: true
           fetch-depth: 2
       - uses: actions/setup-python@v3
+        with:
+          python-version: '3.11.x'
       - name: Install CLI
         run: |
           pip install codecov-cli
@@ -107,6 +111,8 @@ jobs:
           submodules: true
           fetch-depth: 0
       - uses: actions/setup-python@v3
+        with:
+          python-version: '3.11.x'
       - name: Install CLI
         run: |
           pip install -r requirements.txt -r tests/requirements.txt

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,7 @@ jobs:
           fetch-depth: 2
       - uses: actions/setup-python@v3
         with:
+          # Because of https://github.com/tree-sitter/py-tree-sitter/issues/162
           python-version: '3.11.x'
       - name: Install CLI
         run: |
@@ -90,6 +91,7 @@ jobs:
           fetch-depth: 2
       - uses: actions/setup-python@v3
         with:
+          # Because of https://github.com/tree-sitter/py-tree-sitter/issues/162
           python-version: '3.11.x'
       - name: Install CLI
         run: |
@@ -112,6 +114,7 @@ jobs:
           fetch-depth: 0
       - uses: actions/setup-python@v3
         with:
+          # Because of https://github.com/tree-sitter/py-tree-sitter/issues/162
           python-version: '3.11.x'
       - name: Install CLI
         run: |

--- a/codecov_cli/commands/labelanalysis.py
+++ b/codecov_cli/commands/labelanalysis.py
@@ -341,7 +341,7 @@ def _dry_run_json_output(
         runner_options=runner_options,
         ats_tests_to_run=sorted(labels_to_run),
         ats_tests_to_skip=sorted(labels_to_skip),
-        ats_error=fallback_reason,
+        ats_fallback_reason=fallback_reason,
     )
     # ⚠️ DON'T use logger
     # logger goes to stderr, we want it in stdout

--- a/codecov_cli/commands/labelanalysis.py
+++ b/codecov_cli/commands/labelanalysis.py
@@ -157,6 +157,7 @@ def label_analysis(
                 runner,
                 dry_run=dry_run,
                 dry_run_format=dry_run_format,
+                fallback_reason="codecov_unavailable",
             )
             return
 
@@ -189,6 +190,13 @@ def label_analysis(
                     LabelAnalysisRequestResult(request_result),
                     runner,
                     dry_run_format,
+                    # It's possible that the task had processing errors and fallback to all tests
+                    # Even though it's marked as FINISHED (not ERROR) it's not a true success
+                    fallback_reason=(
+                        "test_list_processing_errors"
+                        if resp_json.get("errors", None)
+                        else None
+                    ),
                 )
             return
         if resp_json["state"] == "error":
@@ -207,6 +215,7 @@ def label_analysis(
                 runner=runner,
                 dry_run=dry_run,
                 dry_run_format=dry_run_format,
+                fallback_reason="test_list_processing_failed",
             )
             return
         if max_wait_time and (time.monotonic() - start_wait) > max_wait_time:
@@ -218,6 +227,7 @@ def label_analysis(
                 runner=runner,
                 dry_run=dry_run,
                 dry_run_format=dry_run_format,
+                fallback_reason="max_wait_time_exceeded",
             )
             return
         logger.info("Waiting more time for result...")
@@ -322,12 +332,16 @@ def _send_labelanalysis_request(payload, url, token_header):
 
 
 def _dry_run_json_output(
-    labels_to_run: set, labels_to_skip: set, runner_options: List[str]
+    labels_to_run: set,
+    labels_to_skip: set,
+    runner_options: List[str],
+    fallback_reason: str = None,
 ) -> None:
     output_as_dict = dict(
         runner_options=runner_options,
         ats_tests_to_run=sorted(labels_to_run),
         ats_tests_to_skip=sorted(labels_to_skip),
+        ats_error=fallback_reason,
     )
     # ⚠️ DON'T use logger
     # logger goes to stderr, we want it in stdout
@@ -335,8 +349,14 @@ def _dry_run_json_output(
 
 
 def _dry_run_list_output(
-    labels_to_run: set, labels_to_skip: set, runner_options: List[str]
+    labels_to_run: set,
+    labels_to_skip: set,
+    runner_options: List[str],
+    fallback_reason: str = None,
 ) -> None:
+    if fallback_reason:
+        logger.warning(f"label-analysis didn't run correctly. Error: {fallback_reason}")
+
     to_run_line = " ".join(
         sorted(map(lambda l: f"'{l}'", runner_options))
         + sorted(map(lambda l: f"'{l}'", labels_to_run))
@@ -355,6 +375,10 @@ def _dry_run_output(
     result: LabelAnalysisRequestResult,
     runner: LabelAnalysisRunnerInterface,
     dry_run_format: str,
+    *,
+    # If we have a fallback reason it means that calculating the list of tests to run
+    # failed at some point. So it was not a completely successful task.
+    fallback_reason: str = None,
 ):
     labels_to_run = set(
         result.absent_labels + result.global_level_labels + result.present_diff_labels
@@ -368,13 +392,16 @@ def _dry_run_output(
     # Because dry_run_format is a click.Choice we can
     # be sure the value will be in the dict of choices
     fn_to_use = format_lookup[dry_run_format]
-    fn_to_use(labels_to_run, labels_to_skip, runner.dry_run_runner_options)
+    fn_to_use(
+        labels_to_run, labels_to_skip, runner.dry_run_runner_options, fallback_reason
+    )
 
 
 def _fallback_to_collected_labels(
     collected_labels: List[str],
     runner: LabelAnalysisRunnerInterface,
     *,
+    fallback_reason: str = None,
     dry_run: bool = False,
     dry_run_format: Optional[pathlib.Path] = None,
 ) -> dict:
@@ -393,7 +420,10 @@ def _fallback_to_collected_labels(
             return runner.process_labelanalysis_result(fake_response)
         else:
             return _dry_run_output(
-                LabelAnalysisRequestResult(fake_response), runner, dry_run_format
+                LabelAnalysisRequestResult(fake_response),
+                runner,
+                dry_run_format,
+                fallback_reason=fallback_reason,
             )
     logger.error("Cannot fallback to collected labels because no labels were collected")
     raise click.ClickException("Failed to get list of labels to run")

--- a/tests/commands/test_invoke_labelanalysis.py
+++ b/tests/commands/test_invoke_labelanalysis.py
@@ -125,7 +125,7 @@ class TestLabelAnalysisNotInvoke(object):
             "runner_options": ["--option=1", "--option=2"],
             "ats_tests_to_skip": ["label_3", "label_4"],
             "ats_tests_to_run": ["label_1", "label_2"],
-            "ats_error": None,
+            "ats_fallback_reason": None,
         }
 
     def test__dry_run_json_output_fallback_reason(self):
@@ -147,7 +147,7 @@ class TestLabelAnalysisNotInvoke(object):
             "runner_options": ["--option=1", "--option=2"],
             "ats_tests_to_skip": [],
             "ats_tests_to_run": ["label_1", "label_2", "label_3", "label_4"],
-            "ats_error": "test_list_processing_errors",
+            "ats_fallback_reason": "test_list_processing_errors",
         }
 
     def test__dry_run_space_separated_list_output(self):
@@ -353,12 +353,14 @@ class TestLabelAnalysisCommand(object):
                 fake_runner.process_labelanalysis_result.assert_not_called()
         # Dry run format defaults to json
         print(result.stdout)
-        ats_error = "test_list_processing_errors" if processing_errors else None
+        ats_fallback_reason = (
+            "test_list_processing_errors" if processing_errors else None
+        )
         assert json.loads(result.stdout) == {
             "runner_options": ["--labels"],
             "ats_tests_to_run": ["test_absent", "test_global", "test_in_diff"],
             "ats_tests_to_skip": ["test_present"],
-            "ats_error": ats_error,
+            "ats_fallback_reason": ats_fallback_reason,
         }
 
     def test_invoke_label_analysis_dry_run_pytest_format(
@@ -511,7 +513,7 @@ class TestLabelAnalysisCommand(object):
             "runner_options": ["--labels"],
             "ats_tests_to_run": sorted(collected_labels),
             "ats_tests_to_skip": [],
-            "ats_error": "codecov_unavailable",
+            "ats_fallback_reason": "codecov_unavailable",
         }
         assert result.exit_code == 0
 
@@ -629,7 +631,7 @@ class TestLabelAnalysisCommand(object):
             "runner_options": ["--labels"],
             "ats_tests_to_run": sorted(collected_labels),
             "ats_tests_to_skip": [],
-            "ats_error": "test_list_processing_failed",
+            "ats_fallback_reason": "test_list_processing_failed",
         }
         assert result.exit_code == 0
 
@@ -739,7 +741,7 @@ class TestLabelAnalysisCommand(object):
             "runner_options": ["--labels"],
             "ats_tests_to_run": sorted(collected_labels),
             "ats_tests_to_skip": [],
-            "ats_error": "max_wait_time_exceeded",
+            "ats_fallback_reason": "max_wait_time_exceeded",
         }
         assert result.exit_code == 0
 

--- a/tests/commands/test_invoke_labelanalysis.py
+++ b/tests/commands/test_invoke_labelanalysis.py
@@ -117,6 +117,7 @@ class TestLabelAnalysisNotInvoke(object):
                     labels_to_run=list_to_run,
                     labels_to_skip=list_to_skip,
                     runner_options=runner_options,
+                    fallback_reason=None,
                 )
                 stdout = out.getvalue()
 
@@ -124,9 +125,32 @@ class TestLabelAnalysisNotInvoke(object):
             "runner_options": ["--option=1", "--option=2"],
             "ats_tests_to_skip": ["label_3", "label_4"],
             "ats_tests_to_run": ["label_1", "label_2"],
+            "ats_error": None,
         }
 
-    def test__dry_run_json_output(self):
+    def test__dry_run_json_output_fallback_reason(self):
+        list_to_run = ["label_1", "label_2", "label_3", "label_4"]
+        list_to_skip = []
+        runner_options = ["--option=1", "--option=2"]
+
+        with StringIO() as out:
+            with redirect_stdout(out):
+                _dry_run_json_output(
+                    labels_to_run=list_to_run,
+                    labels_to_skip=list_to_skip,
+                    runner_options=runner_options,
+                    fallback_reason="test_list_processing_errors",
+                )
+                stdout = out.getvalue()
+
+        assert json.loads(stdout) == {
+            "runner_options": ["--option=1", "--option=2"],
+            "ats_tests_to_skip": [],
+            "ats_tests_to_run": ["label_1", "label_2", "label_3", "label_4"],
+            "ats_error": "test_list_processing_errors",
+        }
+
+    def test__dry_run_space_separated_list_output(self):
         list_to_run = ["label_1", "label_2"]
         list_to_skip = ["label_3", "label_4"]
         runner_options = ["--option=1", "--option=2"]
@@ -271,7 +295,10 @@ class TestLabelAnalysisCommand(object):
         )
         print(result.output)
 
-    def test_invoke_label_analysis_dry_run(self, get_labelanalysis_deps, mocker):
+    @pytest.mark.parametrize("processing_errors", [[], [{"error": "missing_data"}]])
+    def test_invoke_label_analysis_dry_run(
+        self, processing_errors, get_labelanalysis_deps, mocker
+    ):
         mock_get_runner = get_labelanalysis_deps["mock_get_runner"]
         fake_runner = get_labelanalysis_deps["fake_runner"]
 
@@ -304,7 +331,11 @@ class TestLabelAnalysisCommand(object):
             rsps.add(
                 responses.GET,
                 "https://api.codecov.io/labels/labels-analysis/label-analysis-request-id",
-                json={"state": "finished", "result": label_analysis_result},
+                json={
+                    "state": "finished",
+                    "result": label_analysis_result,
+                    "errors": processing_errors,
+                },
             )
             cli_runner = CliRunner(mix_stderr=False)
             with cli_runner.isolated_filesystem():
@@ -322,10 +353,12 @@ class TestLabelAnalysisCommand(object):
                 fake_runner.process_labelanalysis_result.assert_not_called()
         # Dry run format defaults to json
         print(result.stdout)
+        ats_error = "test_list_processing_errors" if processing_errors else None
         assert json.loads(result.stdout) == {
             "runner_options": ["--labels"],
             "ats_tests_to_run": ["test_absent", "test_global", "test_in_diff"],
             "ats_tests_to_skip": ["test_present"],
+            "ats_error": ats_error,
         }
 
     def test_invoke_label_analysis_dry_run_pytest_format(
@@ -444,13 +477,12 @@ class TestLabelAnalysisCommand(object):
             print(result.output)
         assert result.exit_code == 0
 
-    def test_fallback_dry_run(self, get_labelanalysis_deps, mocker, use_verbose_option):
+    def test_fallback_collected_labels_covecov_500_error_dry_run(
+        self, get_labelanalysis_deps, mocker
+    ):
         mock_get_runner = get_labelanalysis_deps["mock_get_runner"]
         fake_runner = get_labelanalysis_deps["fake_runner"]
         collected_labels = get_labelanalysis_deps["collected_labels"]
-        mock_dry_run = mocker.patch(
-            "codecov_cli.commands.labelanalysis._dry_run_output"
-        )
         with responses.RequestsMock() as rsps:
             rsps.add(
                 responses.POST,
@@ -460,29 +492,27 @@ class TestLabelAnalysisCommand(object):
                     matchers.header_matcher({"Authorization": "Repotoken STATIC_TOKEN"})
                 ],
             )
-            cli_runner = CliRunner()
-            result = cli_runner.invoke(
-                cli,
-                [
-                    "label-analysis",
-                    "--token=STATIC_TOKEN",
-                    f"--base-sha={FAKE_BASE_SHA}",
-                    "--dry-run",
-                ],
-                obj={},
-            )
-            mock_get_runner.assert_called()
-            fake_runner.process_labelanalysis_result.assert_not_called()
-            mock_dry_run.assert_called_with(
-                {
-                    "present_report_labels": [],
-                    "absent_labels": collected_labels,
-                    "present_diff_labels": [],
-                    "global_level_labels": [],
-                },
-                fake_runner,
-                "json",
-            )
+            cli_runner = CliRunner(mix_stderr=False)
+            with cli_runner.isolated_filesystem():
+                result = cli_runner.invoke(
+                    cli,
+                    [
+                        "label-analysis",
+                        "--token=STATIC_TOKEN",
+                        f"--base-sha={FAKE_BASE_SHA}",
+                        "--dry-run",
+                    ],
+                    obj={},
+                )
+                mock_get_runner.assert_called()
+                fake_runner.process_labelanalysis_result.assert_not_called()
+        # Dry run format defaults to json
+        assert json.loads(result.stdout) == {
+            "runner_options": ["--labels"],
+            "ats_tests_to_run": sorted(collected_labels),
+            "ats_tests_to_skip": [],
+            "ats_error": "codecov_unavailable",
+        }
         assert result.exit_code == 0
 
     def test_fallback_collected_labels_codecov_error_processing_label_analysis(
@@ -544,6 +574,65 @@ class TestLabelAnalysisCommand(object):
             print(result.output)
         assert result.exit_code == 0
 
+    def test_fallback_collected_labels_codecov_error_processing_label_analysis_dry_run(
+        self, get_labelanalysis_deps, mocker, use_verbose_option
+    ):
+        mock_get_runner = get_labelanalysis_deps["mock_get_runner"]
+        fake_runner = get_labelanalysis_deps["fake_runner"]
+        collected_labels = get_labelanalysis_deps["collected_labels"]
+
+        with responses.RequestsMock() as rsps:
+            rsps.add(
+                responses.POST,
+                "https://api.codecov.io/labels/labels-analysis",
+                json={"external_id": "label-analysis-request-id"},
+                status=201,
+                match=[
+                    matchers.header_matcher({"Authorization": "Repotoken STATIC_TOKEN"})
+                ],
+            )
+            rsps.add(
+                responses.PATCH,
+                "https://api.codecov.io/labels/labels-analysis/label-analysis-request-id",
+                json={"external_id": "label-analysis-request-id"},
+                status=201,
+                match=[
+                    matchers.header_matcher({"Authorization": "Repotoken STATIC_TOKEN"})
+                ],
+            )
+            rsps.add(
+                responses.GET,
+                "https://api.codecov.io/labels/labels-analysis/label-analysis-request-id",
+                json={
+                    "state": "error",
+                    "external_id": "uuid4-external-id",
+                    "base_commit": "BASE_COMMIT_SHA",
+                    "head_commit": "HEAD_COMMIT_SHA",
+                },
+            )
+            cli_runner = CliRunner(mix_stderr=False)
+            with cli_runner.isolated_filesystem():
+                result = cli_runner.invoke(
+                    cli,
+                    [
+                        "label-analysis",
+                        "--token=STATIC_TOKEN",
+                        f"--base-sha={FAKE_BASE_SHA}",
+                        "--dry-run",
+                    ],
+                    obj={},
+                )
+                mock_get_runner.assert_called()
+                fake_runner.process_labelanalysis_result.assert_not_called()
+        # Dry run format defaults to json
+        assert json.loads(result.stdout) == {
+            "runner_options": ["--labels"],
+            "ats_tests_to_run": sorted(collected_labels),
+            "ats_tests_to_skip": [],
+            "ats_error": "test_list_processing_failed",
+        }
+        assert result.exit_code == 0
+
     def test_fallback_collected_labels_codecov_max_wait_time_exceeded(
         self, get_labelanalysis_deps, mocker, use_verbose_option
     ):
@@ -598,6 +687,61 @@ class TestLabelAnalysisCommand(object):
                 "global_level_labels": [],
             }
         )
+
+    def test_fallback_collected_labels_codecov_max_wait_time_exceeded_dry_run(
+        self, get_labelanalysis_deps, mocker, use_verbose_option
+    ):
+        mock_get_runner = get_labelanalysis_deps["mock_get_runner"]
+        fake_runner = get_labelanalysis_deps["fake_runner"]
+        collected_labels = get_labelanalysis_deps["collected_labels"]
+        mocker.patch.object(labelanalysis_time, "monotonic", side_effect=[0, 6])
+
+        with responses.RequestsMock() as rsps:
+            rsps.add(
+                responses.POST,
+                "https://api.codecov.io/labels/labels-analysis",
+                json={"external_id": "label-analysis-request-id"},
+                status=201,
+                match=[
+                    matchers.header_matcher({"Authorization": "Repotoken STATIC_TOKEN"})
+                ],
+            )
+            rsps.add(
+                responses.PATCH,
+                "https://api.codecov.io/labels/labels-analysis/label-analysis-request-id",
+                json={"external_id": "label-analysis-request-id"},
+                status=201,
+                match=[
+                    matchers.header_matcher({"Authorization": "Repotoken STATIC_TOKEN"})
+                ],
+            )
+            rsps.add(
+                responses.GET,
+                "https://api.codecov.io/labels/labels-analysis/label-analysis-request-id",
+                json={"state": "processing"},
+            )
+            cli_runner = CliRunner(mix_stderr=False)
+            result = cli_runner.invoke(
+                cli,
+                [
+                    "label-analysis",
+                    "--token=STATIC_TOKEN",
+                    f"--base-sha={FAKE_BASE_SHA}",
+                    "--max-wait-time=5",
+                    "--dry-run",
+                ],
+                obj={},
+            )
+            mock_get_runner.assert_called()
+            fake_runner.process_labelanalysis_result.assert_not_called()
+        # Dry run format defaults to json
+        assert json.loads(result.stdout) == {
+            "runner_options": ["--labels"],
+            "ats_tests_to_run": sorted(collected_labels),
+            "ats_tests_to_skip": [],
+            "ats_error": "max_wait_time_exceeded",
+        }
+        assert result.exit_code == 0
 
     def test_first_labelanalysis_request_fails_but_second_works(
         self, get_labelanalysis_deps, mocker, use_verbose_option


### PR DESCRIPTION
label-analysis was build to be dependable. Even if the calculation fails (which is rare)
we have many fallback systems in place, so that you can add the label analysis step before
tests and make sure the tests will run.
The fallbacks come with a price, though: running all tests.

One thing we don't do so well is surfacing when label-analysis fallback in a way customers can
use to help build their confidence in label-analysis.

We do have logs that point out that something was not successful and that we tried to fallback.
Sentry specifically requested that we also surface this information in the dry-run output.

These changes do that, letting users check the dry-run output if label-analysis had to
fallback, and if so, what was the reason for it.
(only for JSON tho, because space-separated list I thought would be too polluting)

closes codecov/engineering-team#711