### PR TITLE
chore: remove smart-open

### DIFF
--- a/codecov_cli/plugins/compress_pycoverage_contexts.py
+++ b/codecov_cli/plugins/compress_pycoverage_contexts.py
@@ -5,7 +5,6 @@ from decimal import Decimal
 from typing import Any, List
 
 import ijson
-from smart_open import open
 
 from codecov_cli.plugins.types import PreparationPluginReturn
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -37,9 +37,9 @@ requests==2.31.0
 responses==0.21.0
     # via codecov-cli (setup.py)
 rfc3986[idna2008]==1.5.0
-    # via httpx
-smart-open==6.4.0
-    # via codecov-cli (setup.py)
+    # via
+    #   httpx
+    #   rfc3986
 sniffio==1.3.0
     # via
     #   anyio

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,6 @@ setup(
         "ijson==3.*",
         "pyyaml==6.*",
         "responses==0.21.*",
-        "smart-open==6.*",
         "tree-sitter==0.20.*",
     ],
     entry_points={


### PR DESCRIPTION
We want to add codecov-cli to getsentry/pypi.
It was asked that we drop the smart-open dependency.

I went back and checked that smart-open is really used for dealing with
files in remote storage and decompressing things under-the-hood.
We don't need any of that, and are well served by the default open function.

So it's fine to drop it.