### PR TITLE
Fix lineno being unset

### DIFF
--- a/codecov_cli/services/upload/upload_collector.py
+++ b/codecov_cli/services/upload/upload_collector.py
@@ -112,6 +112,9 @@ class UploadCollector(object):
 
         try:
             with open(filename, "r") as f:
+                # If lineno is unset that means that the
+                # file is empty thus the eof should be 0
+                # so lineno will be set to -1 here
                 lineno = -1
                 for lineno, line_content in enumerate(f):
                     if any(

--- a/codecov_cli/services/upload/upload_collector.py
+++ b/codecov_cli/services/upload/upload_collector.py
@@ -116,6 +116,8 @@ class UploadCollector(object):
                 # file is empty thus the eof should be 0
                 # so lineno will be set to -1 here
                 lineno = -1
+                # overwrite lineno in this for loop
+                # if f is empty, lineno stays at -1
                 for lineno, line_content in enumerate(f):
                     if any(
                         pattern.match(line_content)

--- a/codecov_cli/services/upload/upload_collector.py
+++ b/codecov_cli/services/upload/upload_collector.py
@@ -112,6 +112,7 @@ class UploadCollector(object):
 
         try:
             with open(filename, "r") as f:
+                lineno = -1
                 for lineno, line_content in enumerate(f):
                     if any(
                         pattern.match(line_content)
@@ -123,7 +124,6 @@ class UploadCollector(object):
                         for pattern in fix_patterns_to_apply.without_reason
                     ):
                         fixed_lines_without_reason.add(lineno + 1)
-
                 if fix_patterns_to_apply.eof:
                     eof = lineno + 1
         except UnicodeDecodeError as err:


### PR DESCRIPTION
If lineno is unset that means that the file is empty thus the eof should be 0, so lineno will be -1.

Fixes: https://github.com/codecov/codecov-cli/issues/320