### PR TITLE
amend branch names to be forked-slug:branch-name

### DIFF
--- a/codecov_cli/helpers/git.py
+++ b/codecov_cli/helpers/git.py
@@ -97,11 +97,7 @@ def is_fork_pr(pull_dict):
     takes in dict: pull_dict
     returns true if PR is made in a fork context, false if not.
     """
-    return (
-        True
-        if pull_dict and pull_dict["head"]["slug"] != pull_dict["base"]["slug"]
-        else False
-    )
+    return pull_dict and pull_dict["head"]["slug"] != pull_dict["base"]["slug"]
 
 
 def get_pull(service, slug, pr_num):

--- a/codecov_cli/helpers/git.py
+++ b/codecov_cli/helpers/git.py
@@ -92,14 +92,24 @@ def parse_git_service(remote_repo_url: str):
         return None
 
 
-def is_fork_pr(pr_num, slug, service):
+def is_fork_pr(pull_dict):
     """
-    takes in pull request number, slug in the owner/repo format, and the git service e.g. github, gitlab etc.
+    takes in dict: pull_dict
     returns true if PR is made in a fork context, false if not.
+    """
+    return (
+        True
+        if pull_dict and pull_dict["head"]["slug"] != pull_dict["base"]["slug"]
+        else False
+    )
+
+
+def get_pull(service, slug, pr_num):
+    """
+    takes in str git service e.g. github, gitlab etc., slug in the owner/repo format, and the pull request number
+    returns the pull request info gotten from the git service provider if successful, None if not
     """
     git_service = get_git_service(service)
     if git_service:
         pull_dict = git_service.get_pull_request(slug, pr_num)
-        if pull_dict and pull_dict["head"]["slug"] != pull_dict["base"]["slug"]:
-            return True
-    return False
+        return pull_dict

--- a/codecov_cli/services/report/__init__.py
+++ b/codecov_cli/services/report/__init__.py
@@ -8,7 +8,7 @@ import requests
 from codecov_cli.helpers import request
 from codecov_cli.helpers.config import CODECOV_API_URL
 from codecov_cli.helpers.encoder import decode_slug, encode_slug
-from codecov_cli.helpers.git import is_fork_pr
+from codecov_cli.helpers.git import get_pull, is_fork_pr
 from codecov_cli.helpers.request import (
     get_token_header_or_fail,
     log_warnings_and_errors_if_any,
@@ -49,10 +49,11 @@ def send_create_report_request(
 ):
     data = {"code": code}
     decoded_slug = decode_slug(encoded_slug)
+    pull_dict = (
+        get_pull(service, decoded_slug, pull_request_number) if not token else None
+    )
     headers = (
-        {}
-        if not token and is_fork_pr(pull_request_number, decoded_slug, service)
-        else get_token_header_or_fail(token)
+        {} if not token and is_fork_pr(pull_dict) else get_token_header_or_fail(token)
     )
     upload_url = enterprise_url or CODECOV_API_URL
     url = f"{upload_url}/upload/{service}/{encoded_slug}/commits/{commit_sha}/reports"

--- a/codecov_cli/services/upload/upload_sender.py
+++ b/codecov_cli/services/upload/upload_sender.py
@@ -9,7 +9,7 @@ from typing import Any, Dict
 from codecov_cli import __version__ as codecov_cli_version
 from codecov_cli.helpers.config import CODECOV_API_URL
 from codecov_cli.helpers.encoder import encode_slug
-from codecov_cli.helpers.git import is_fork_pr
+from codecov_cli.helpers.git import get_pull, is_fork_pr
 from codecov_cli.helpers.request import (
     get_token_header_or_fail,
     send_post_request,
@@ -54,9 +54,12 @@ class UploadSender(object):
         }
 
         # Data to upload to Codecov
+        pull_dict = (
+            get_pull(git_service, slug, pull_request_number) if not token else None
+        )
         headers = (
             {}
-            if not token and is_fork_pr(pull_request_number, slug, git_service)
+            if not token and is_fork_pr(pull_dict)
             else get_token_header_or_fail(token)
         )
         encoded_slug = encode_slug(slug)

--- a/tests/helpers/test_git.py
+++ b/tests/helpers/test_git.py
@@ -160,15 +160,15 @@ def test_pr_is_not_fork_pr(mocker):
         "get",
         side_effect=mock_request,
     )
-    encoded_slug = "codecov::::codecov-cli"
-    assert not git.is_fork_pr(1, encoded_slug, "github")
+    pull_dict = git.get_pull("github", "codecov/codecov-cli", 1)
+    assert not git.is_fork_pr(pull_dict)
 
 
 def test_pr_is_fork_pr(mocker):
     def mock_request(*args, headers={}, **kwargs):
         assert headers["X-GitHub-Api-Version"] == "2022-11-28"
         res = {
-            "url": "https://api.github.com/repos/codecov/codecov-cli/pulls/325",
+            "url": "https://api.github.com/repos/codecov/codecov-cli/pulls/1",
             "head": {
                 "sha": "123",
                 "label": "codecov-cli:branch",
@@ -192,8 +192,8 @@ def test_pr_is_fork_pr(mocker):
         "get",
         side_effect=mock_request,
     )
-    encoded_slug = "codecov::::codecov-cli"
-    assert git.is_fork_pr(1, encoded_slug, "github")
+    pull_dict = git.get_pull("github", "codecov/codecov-cli", 1)
+    assert git.is_fork_pr(pull_dict)
 
 
 def test_pr_not_found(mocker):
@@ -209,5 +209,5 @@ def test_pr_not_found(mocker):
         "get",
         side_effect=mock_request,
     )
-    encoded_slug = "codecov::::codecov-cli"
-    assert not git.is_fork_pr(1, encoded_slug, "github")
+    pull_dict = git.get_pull("github", "codecov/codecov-cli", 1)
+    assert not git.is_fork_pr(pull_dict)

--- a/tests/services/commit/test_commit_service.py
+++ b/tests/services/commit/test_commit_service.py
@@ -1,6 +1,9 @@
+import json
 import uuid
 
+import requests
 from click.testing import CliRunner
+from requests import Response
 
 from codecov_cli.services.commit import create_commit_logic, send_commit_data
 from codecov_cli.types import RequestError, RequestResult, RequestResultWarning
@@ -139,3 +142,58 @@ def test_commit_sender_403(mocker):
         params={},
     )
     mocked_response.assert_called_once()
+
+
+def test_commit_sender_with_forked_repo(mocker):
+    mocked_response = mocker.patch(
+        "codecov_cli.services.commit.send_post_request",
+        return_value=mocker.MagicMock(status_code=200, text="success"),
+    )
+
+    def mock_request(*args, headers={}, **kwargs):
+        assert headers["X-GitHub-Api-Version"] == "2022-11-28"
+        res = {
+            "url": "https://api.github.com/repos/codecov/codecov-cli/pulls/1",
+            "head": {
+                "sha": "123",
+                "label": "codecov-cli:branch",
+                "ref": "branch",
+                "repo": {"full_name": "user_forked_repo/codecov-cli"},
+            },
+            "base": {
+                "sha": "123",
+                "label": "codecov-cli:main",
+                "ref": "main",
+                "repo": {"full_name": "codecov/codecov-cli"},
+            },
+        }
+        response = Response()
+        response.status_code = 200
+        response._content = json.dumps(res).encode("utf-8")
+        return response
+
+    mocker.patch.object(
+        requests,
+        "get",
+        side_effect=mock_request,
+    )
+    res = send_commit_data(
+        "commit_sha",
+        "parent_sha",
+        "1",
+        "branch",
+        "codecov::::codecov-cli",
+        None,
+        "github",
+        None,
+    )
+    mocked_response.assert_called_with(
+        url="https://api.codecov.io/upload/github/codecov::::codecov-cli/commits",
+        data={
+            "commitid": "commit_sha",
+            "parent_commit_id": "parent_sha",
+            "pullid": "1",
+            "branch": "user_forked_repo/codecov-cli:branch",
+        },
+        headers={},
+    )


### PR DESCRIPTION
- taking get_pull out of is_fork_pr for usability. I don't think it's the responsibility of is_fork_pr to do the request and get the pull's information 
- overriding branch in commit's endpoint since that's the only command that actually uses it and sends it in part of the request. 