### PR TITLE
add X-Tokenless header when uploading from fork

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,7 +225,7 @@ Codecov-cli supports user input. These inputs, along with their descriptions and
 | :---:     |     :---:   |    :---:   | 
 | -C, --sha, --commit-sha TEXT    |Commit SHA (with 40 chars) | Required
 | -r, --slug TEXT                 |owner/repo slug used instead of the private repo token in Self-hosted | Required
-| -t, --token UUID                |Codecov upload token | Required
+| -t, --token TEXT                |Codecov upload token | Required
 | --git-service | Git provider. Options: github, gitlab, bitbucket, github_enterprise, gitlab_enterprise, bitbucket_server | Optional
 | -h,--help                      |Show this message and exit.
 

--- a/codecov_cli/commands/base_picking.py
+++ b/codecov_cli/commands/base_picking.py
@@ -1,6 +1,5 @@
 import logging
 import typing
-import uuid
 
 import click
 
@@ -36,7 +35,6 @@ logger = logging.getLogger("codecovcli")
     "-t",
     "--token",
     help="Codecov upload token",
-    type=click.UUID,
     envvar="CODECOV_TOKEN",
 )
 @click.option(
@@ -51,7 +49,7 @@ def pr_base_picking(
     base_sha: str,
     pr: typing.Optional[int],
     slug: typing.Optional[str],
-    token: typing.Optional[uuid.UUID],
+    token: typing.Optional[str],
     service: typing.Optional[str],
 ):
     enterprise_url = ctx.obj.get("enterprise_url")

--- a/codecov_cli/commands/commit.py
+++ b/codecov_cli/commands/commit.py
@@ -1,6 +1,5 @@
 import logging
 import typing
-import uuid
 
 import click
 
@@ -42,7 +41,7 @@ def create_commit(
     pull_request_number: typing.Optional[int],
     branch: typing.Optional[str],
     slug: typing.Optional[str],
-    token: typing.Optional[uuid.UUID],
+    token: typing.Optional[str],
     git_service: typing.Optional[str],
     fail_on_error: bool,
 ):

--- a/codecov_cli/commands/create_report_result.py
+++ b/codecov_cli/commands/create_report_result.py
@@ -1,10 +1,7 @@
 import logging
-import uuid
 
 import click
 
-from codecov_cli.fallbacks import CodecovOption, FallbackFieldEnum
-from codecov_cli.helpers.git import GitService
 from codecov_cli.helpers.options import global_options
 from codecov_cli.services.report import create_report_results_logic
 
@@ -23,7 +20,7 @@ def create_report_results(
     code: str,
     slug: str,
     git_service: str,
-    token: uuid.UUID,
+    token: str,
     fail_on_error: bool,
 ):
     enterprise_url = ctx.obj.get("enterprise_url")

--- a/codecov_cli/commands/empty_upload.py
+++ b/codecov_cli/commands/empty_upload.py
@@ -1,6 +1,5 @@
 import logging
 import typing
-import uuid
 
 import click
 
@@ -19,7 +18,7 @@ def empty_upload(
     ctx,
     commit_sha: str,
     slug: typing.Optional[str],
-    token: typing.Optional[uuid.UUID],
+    token: typing.Optional[str],
     git_service: typing.Optional[str],
     fail_on_error: typing.Optional[bool],
 ):

--- a/codecov_cli/commands/get_report_results.py
+++ b/codecov_cli/commands/get_report_results.py
@@ -1,5 +1,4 @@
 import logging
-import uuid
 
 import click
 
@@ -24,7 +23,7 @@ def get_report_results(
     code: str,
     slug: str,
     git_service: str,
-    token: uuid.UUID,
+    token: str,
     fail_on_error: bool,
 ):
     enterprise_url = ctx.obj.get("enterprise_url")

--- a/codecov_cli/commands/report.py
+++ b/codecov_cli/commands/report.py
@@ -1,10 +1,8 @@
 import logging
-import uuid
 
 import click
 
 from codecov_cli.fallbacks import CodecovOption, FallbackFieldEnum
-from codecov_cli.helpers.git import GitService
 from codecov_cli.helpers.options import global_options
 from codecov_cli.services.report import create_report_logic
 
@@ -32,7 +30,7 @@ def create_report(
     code: str,
     slug: str,
     git_service: str,
-    token: uuid.UUID,
+    token: str,
     fail_on_error: bool,
     pull_request_number: int,
 ):

--- a/codecov_cli/commands/send_notifications.py
+++ b/codecov_cli/commands/send_notifications.py
@@ -1,6 +1,5 @@
 import logging
 import typing
-import uuid
 
 import click
 
@@ -19,7 +18,7 @@ def send_notifications(
     ctx,
     commit_sha: str,
     slug: typing.Optional[str],
-    token: typing.Optional[uuid.UUID],
+    token: typing.Optional[str],
     git_service: typing.Optional[str],
     fail_on_error: bool,
 ):

--- a/codecov_cli/commands/upload.py
+++ b/codecov_cli/commands/upload.py
@@ -2,7 +2,6 @@ import logging
 import os
 import pathlib
 import typing
-import uuid
 
 import click
 
@@ -185,7 +184,7 @@ def do_upload(
     coverage_files_search_explicitly_listed_files: typing.List[pathlib.Path],
     disable_search: bool,
     disable_file_fixes: bool,
-    token: typing.Optional[uuid.UUID],
+    token: typing.Optional[str],
     plugin_names: typing.List[str],
     branch: typing.Optional[str],
     slug: typing.Optional[str],

--- a/codecov_cli/commands/upload_process.py
+++ b/codecov_cli/commands/upload_process.py
@@ -1,7 +1,6 @@
 import logging
 import pathlib
 import typing
-import uuid
 
 import click
 
@@ -38,7 +37,7 @@ def upload_process(
     coverage_files_search_explicitly_listed_files: typing.List[pathlib.Path],
     disable_search: bool,
     disable_file_fixes: bool,
-    token: typing.Optional[uuid.UUID],
+    token: typing.Optional[str],
     plugin_names: typing.List[str],
     branch: typing.Optional[str],
     slug: typing.Optional[str],

--- a/codecov_cli/helpers/options.py
+++ b/codecov_cli/helpers/options.py
@@ -31,7 +31,6 @@ _global_options = [
         "-t",
         "--token",
         help="Codecov upload token",
-        type=click.UUID,
         envvar="CODECOV_TOKEN",
     ),
     click.option(

--- a/codecov_cli/helpers/request.py
+++ b/codecov_cli/helpers/request.py
@@ -1,5 +1,4 @@
 import logging
-import uuid
 from time import sleep
 
 import click
@@ -75,14 +74,12 @@ def send_post_request(
     return request_result(post(url=url, data=data, headers=headers, params=params))
 
 
-def get_token_header_or_fail(token: uuid.UUID) -> dict:
+def get_token_header_or_fail(token: str) -> dict:
     if token is None:
         raise click.ClickException(
             "Codecov token not found. Please provide Codecov token with -t flag."
         )
-    if not isinstance(token, uuid.UUID):
-        raise click.ClickException(f"Token must be UUID. Received {type(token)}")
-    return {"Authorization": f"token {token.hex}"}
+    return {"Authorization": f"token {token}"}
 
 
 @retry_request

--- a/codecov_cli/services/commit/__init__.py
+++ b/codecov_cli/services/commit/__init__.py
@@ -1,6 +1,5 @@
 import logging
 import typing
-import uuid
 
 from codecov_cli.helpers.config import CODECOV_API_URL
 from codecov_cli.helpers.encoder import decode_slug, encode_slug
@@ -20,7 +19,7 @@ def create_commit_logic(
     pr: typing.Optional[str],
     branch: typing.Optional[str],
     slug: typing.Optional[str],
-    token: uuid.UUID,
+    token: str,
     service: typing.Optional[str],
     enterprise_url: typing.Optional[str] = None,
     fail_on_error: bool = False,

--- a/codecov_cli/services/report/__init__.py
+++ b/codecov_cli/services/report/__init__.py
@@ -1,7 +1,6 @@
 import json
 import logging
 import time
-import uuid
 
 import requests
 
@@ -25,7 +24,7 @@ def create_report_logic(
     code: str,
     slug: str,
     service: str,
-    token: uuid.UUID,
+    token: str,
     enterprise_url: str,
     pull_request_number: int,
     fail_on_error: bool = False,
@@ -65,7 +64,7 @@ def create_report_results_logic(
     code: str,
     slug: str,
     service: str,
-    token: uuid.UUID,
+    token: str,
     enterprise_url: str,
     fail_on_error: bool = False,
 ):

--- a/codecov_cli/services/upload/__init__.py
+++ b/codecov_cli/services/upload/__init__.py
@@ -1,6 +1,5 @@
 import logging
 import typing
-import uuid
 from pathlib import Path
 
 import click
@@ -39,7 +38,7 @@ def do_upload_logic(
     coverage_files_search_exclude_folders: typing.List[Path],
     coverage_files_search_explicitly_listed_files: typing.List[Path],
     plugin_names: typing.List[str],
-    token: uuid.UUID,
+    token: str,
     branch: typing.Optional[str],
     slug: typing.Optional[str],
     pull_request_number: typing.Optional[str],

--- a/codecov_cli/services/upload/legacy_upload_sender.py
+++ b/codecov_cli/services/upload/legacy_upload_sender.py
@@ -1,9 +1,6 @@
 import logging
 import typing
-import uuid
 from dataclasses import dataclass
-
-import requests
 
 from codecov_cli import __version__ as codecov_cli_version
 from codecov_cli.helpers.config import LEGACY_CODECOV_API_URL
@@ -39,7 +36,7 @@ class LegacyUploadSender(object):
         self,
         upload_data: UploadCollectionResult,
         commit_sha: str,
-        token: uuid.UUID,
+        token: str,
         env_vars: typing.Dict[str, str],
         report_code: str = None,
         name: typing.Optional[str] = None,
@@ -70,7 +67,7 @@ class LegacyUploadSender(object):
         }
 
         if token:
-            headers = {"X-Upload-Token": token.hex}
+            headers = {"X-Upload-Token": token}
         else:
             logger.warning("Token is empty.")
             headers = {"X-Upload-Token": ""}

--- a/codecov_cli/services/upload/upload_sender.py
+++ b/codecov_cli/services/upload/upload_sender.py
@@ -2,7 +2,6 @@ import base64
 import json
 import logging
 import typing
-import uuid
 import zlib
 from typing import Any, Dict
 
@@ -29,7 +28,7 @@ class UploadSender(object):
         self,
         upload_data: UploadCollectionResult,
         commit_sha: str,
-        token: uuid.UUID,
+        token: str,
         env_vars: typing.Dict[str, str],
         report_code: str,
         name: typing.Optional[str] = None,

--- a/tests/commands/test_invoke_upload_process.py
+++ b/tests/commands/test_invoke_upload_process.py
@@ -70,7 +70,7 @@ def test_upload_process_options(mocker):
             "  -C, --sha, --commit-sha TEXT    Commit SHA (with 40 chars)  [required]",
             "  -Z, --fail-on-error             Exit with non-zero code in case of error",
             "  --git-service [github|gitlab|bitbucket|github_enterprise|gitlab_enterprise|bitbucket_server]",
-            "  -t, --token UUID                Codecov upload token",
+            "  -t, --token TEXT                Codecov upload token",
             "  -r, --slug TEXT                 owner/repo slug used instead of the private",
             "                                  repo token in Self-hosted",
             "  --report-code TEXT              The code of the report. If unsure, leave",

--- a/tests/helpers/test_legacy_upload_sender.py
+++ b/tests/helpers/test_legacy_upload_sender.py
@@ -1,4 +1,3 @@
-import uuid
 from urllib import parse
 
 import pytest
@@ -11,7 +10,7 @@ from codecov_cli.types import UploadCollectionResult
 from tests.data import reports_examples
 
 upload_collection = UploadCollectionResult(["1", "apple.py", "3"], [], [])
-random_token = uuid.UUID("f359afb9-8a2a-42ab-a448-c3d267ff495b")
+random_token = "f359afb9-8a2a-42ab-a448-c3d267ff495b"
 random_sha = "845548c6b95223f12e8317a1820705f64beaf69e"
 named_upload_data = {
     "name": "name",
@@ -68,7 +67,7 @@ class TestUploadSender(object):
     def test_upload_sender_post_called_with_right_parameters(
         self, mocked_responses, mocked_legacy_upload_endpoint, mocked_storage_server
     ):
-        headers = {"X-Upload-Token": random_token.hex}
+        headers = {"X-Upload-Token": random_token}
         params = {
             "package": f"codecov-cli/{codecov_cli_version}",
             "commit": random_sha,

--- a/tests/helpers/test_request.py
+++ b/tests/helpers/test_request.py
@@ -57,7 +57,7 @@ def test_get_token_header_or_fail():
     # Test with a valid UUID token
     token = uuid.uuid4()
     result = get_token_header_or_fail(token)
-    assert result == {"Authorization": f"token {token.hex}"}
+    assert result == {"Authorization": f"token {str(token)}"}
 
     # Test with a None token
     token = None
@@ -68,13 +68,6 @@ def test_get_token_header_or_fail():
         str(e.value)
         == "Codecov token not found. Please provide Codecov token with -t flag."
     )
-
-    # Test with an invalid token type
-    token = "invalid_token"
-    with pytest.raises(Exception) as e:
-        get_token_header_or_fail(token)
-
-    assert str(e.value) == f"Token must be UUID. Received {type(token)}"
 
 
 def test_request_retry(mocker, valid_response):

--- a/tests/helpers/test_upload_sender.py
+++ b/tests/helpers/test_upload_sender.py
@@ -1,5 +1,4 @@
 import json
-import uuid
 from pathlib import Path
 
 import pytest
@@ -13,7 +12,7 @@ from codecov_cli.types import UploadCollectionResult, UploadCollectionResultFile
 from tests.data import reports_examples
 
 upload_collection = UploadCollectionResult(["1", "apple.py", "3"], [], [])
-random_token = uuid.UUID("f359afb9-8a2a-42ab-a448-c3d267ff495b")
+random_token = "f359afb9-8a2a-42ab-a448-c3d267ff495b"
 random_sha = "845548c6b95223f12e8317a1820705f64beaf69e"
 named_upload_data = {
     "report_code": "report_code",
@@ -133,7 +132,7 @@ class TestUploadSender(object):
     def test_upload_sender_post_called_with_right_parameters(
         self, mocked_responses, mocked_legacy_upload_endpoint, mocked_storage_server
     ):
-        headers = {"Authorization": f"token {random_token.hex}"}
+        headers = {"Authorization": f"token {random_token}"}
 
         mocked_legacy_upload_endpoint.match = [
             matchers.json_params_matcher(request_data),


### PR DESCRIPTION
Public forks will accept tokenless uploads.
Currently we were just sending an empty header (no Authorization).
These changes add a header `X-Tokenless: fork_slug` so we know
easily that the request is from a fork, and which fork it's from.

I also have a tendency to compulsively add typehints to complex
types.

<!-- Describe your PR here. -->



<!--

  Sentry/Codecov employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.