### PR TITLE
add X-Tokenless header when uploading from fork

### DIFF
--- a/codecov_cli/helpers/git.py
+++ b/codecov_cli/helpers/git.py
@@ -1,9 +1,11 @@
 import logging
 import re
 from enum import Enum
+from typing import Optional
 from urllib.parse import urlparse
 
 from codecov_cli.helpers.encoder import decode_slug
+from codecov_cli.helpers.git_services import PullDict
 from codecov_cli.helpers.git_services.github import Github
 
 slug_regex = re.compile(r"[^/\s]+\/[^/\s]+$")
@@ -92,7 +94,7 @@ def parse_git_service(remote_repo_url: str):
         return None
 
 
-def is_fork_pr(pull_dict):
+def is_fork_pr(pull_dict: PullDict) -> bool:
     """
     takes in dict: pull_dict
     returns true if PR is made in a fork context, false if not.
@@ -100,7 +102,7 @@ def is_fork_pr(pull_dict):
     return pull_dict and pull_dict["head"]["slug"] != pull_dict["base"]["slug"]
 
 
-def get_pull(service, slug, pr_num):
+def get_pull(service, slug, pr_num) -> Optional[PullDict]:
     """
     takes in str git service e.g. github, gitlab etc., slug in the owner/repo format, and the pull request number
     returns the pull request info gotten from the git service provider if successful, None if not

--- a/codecov_cli/helpers/git_services/__init__.py
+++ b/codecov_cli/helpers/git_services/__init__.py
@@ -1,0 +1,14 @@
+from typing import TypedDict
+
+
+class CommitInfo(TypedDict):
+    sha: str
+    label: str
+    ref: str
+    slug: str
+
+
+class PullDict(TypedDict):
+    url: str
+    head: CommitInfo
+    base: CommitInfo

--- a/codecov_cli/helpers/git_services/github.py
+++ b/codecov_cli/helpers/git_services/github.py
@@ -2,12 +2,14 @@ import json
 
 import requests
 
+from codecov_cli.helpers.git_services import PullDict
+
 
 class Github:
     api_url = "https://api.github.com"
     api_version = "2022-11-28"
 
-    def get_pull_request(self, slug, pr_number):
+    def get_pull_request(self, slug, pr_number) -> PullDict:
         pull_url = f"/repos/{slug}/pulls/{pr_number}"
         url = self.api_url + pull_url
         headers = {"X-GitHub-Api-Version": self.api_version}

--- a/codecov_cli/services/commit/__init__.py
+++ b/codecov_cli/services/commit/__init__.py
@@ -46,7 +46,7 @@ def send_commit_data(
     decoded_slug = decode_slug(slug)
     pull_dict = get_pull(service, decoded_slug, pr) if not token else None
     if is_fork_pr(pull_dict):
-        headers = {}
+        headers = {"X-Tokenless": pull_dict["head"]["slug"]}
         branch = pull_dict["head"]["slug"] + ":" + branch
         logger.info("The PR is happening in a forked repo. Using tokenless upload.")
     else:

--- a/codecov_cli/services/report/__init__.py
+++ b/codecov_cli/services/report/__init__.py
@@ -51,9 +51,10 @@ def send_create_report_request(
     pull_dict = (
         get_pull(service, decoded_slug, pull_request_number) if not token else None
     )
-    headers = (
-        {} if not token and is_fork_pr(pull_dict) else get_token_header_or_fail(token)
-    )
+    if is_fork_pr(pull_dict):
+        headers = {"X-Tokenless": pull_dict["head"]["slug"]}
+    else:
+        headers = get_token_header_or_fail(token)
     upload_url = enterprise_url or CODECOV_API_URL
     url = f"{upload_url}/upload/{service}/{encoded_slug}/commits/{commit_sha}/reports"
     return send_post_request(url=url, headers=headers, data=data)

--- a/codecov_cli/services/upload/upload_sender.py
+++ b/codecov_cli/services/upload/upload_sender.py
@@ -56,11 +56,11 @@ class UploadSender(object):
         pull_dict = (
             get_pull(git_service, slug, pull_request_number) if not token else None
         )
-        headers = (
-            {}
-            if not token and is_fork_pr(pull_dict)
-            else get_token_header_or_fail(token)
-        )
+
+        if is_fork_pr(pull_dict):
+            headers = {"X-Tokenless": pull_dict["head"]["slug"]}
+        else:
+            headers = get_token_header_or_fail(token)
         encoded_slug = encode_slug(slug)
         upload_url = enterprise_url or CODECOV_API_URL
         url = f"{upload_url}/upload/{git_service}/{encoded_slug}/commits/{commit_sha}/reports/{report_code}/uploads"

--- a/tests/services/commit/test_commit_service.py
+++ b/tests/services/commit/test_commit_service.py
@@ -195,5 +195,5 @@ def test_commit_sender_with_forked_repo(mocker):
             "pullid": "1",
             "branch": "user_forked_repo/codecov-cli:branch",
         },
-        headers={},
+        headers={"X-Tokenless": "user_forked_repo/codecov-cli"},
     )


### PR DESCRIPTION
Public forks will accept tokenless uploads.
Currently we were just sending an empty header (no Authorization). These changes add a header `X-Tokenless: fork_slug` so we know easily that the request is from a fork, and which fork it's from.

I also have a tendency to compulsively add typehints to complex types.