### PR TITLE
chore: rename 'pytest_command' to 'python_path'

### DIFF
--- a/codecov_cli/runners/pytest_standard_runner.py
+++ b/codecov_cli/runners/pytest_standard_runner.py
@@ -17,12 +17,9 @@ logger = logging.getLogger("codecovcli")
 
 class PytestStandardRunnerConfigParams(dict):
     @property
-    def pytest_command(self) -> List[str]:
-        command_from_config = self.get("pytest_command")
-        if isinstance(command_from_config, str):
-            logger.warning("pytest_command should be a list")
-            command_from_config = command_from_config.split(" ")
-        return command_from_config or ["python", "-m", "pytest"]
+    def python_path(self) -> str:
+        python_path = self.get("python_path")
+        return python_path or "python"
 
     @property
     def collect_tests_options(self) -> List[str]:
@@ -49,6 +46,7 @@ class PytestStandardRunnerConfigParams(dict):
 class PytestStandardRunner(LabelAnalysisRunnerInterface):
 
     dry_run_runner_options = ["--cov-context=test"]
+    params: PytestStandardRunnerConfigParams
 
     def __init__(self, config_params: Optional[dict] = None) -> None:
         super().__init__()
@@ -70,7 +68,7 @@ class PytestStandardRunner(LabelAnalysisRunnerInterface):
         Raises Exception if pytest fails
         Returns the complete pytest output
         """
-        command = self.params.pytest_command + pytest_args
+        command = [self.params.python_path, "-m", "pytest"] + pytest_args
         try:
             result = subprocess.run(
                 command,
@@ -101,7 +99,7 @@ class PytestStandardRunner(LabelAnalysisRunnerInterface):
             "Collecting tests",
             extra=dict(
                 extra_log_attributes=dict(
-                    pytest_command=self.params.pytest_command,
+                    pytest_command=[self.params.python_path, "-m", "pytest"],
                     pytest_options=options_to_use,
                 ),
             ),

--- a/tests/runners/test_pytest_standard_runner.py
+++ b/tests/runners/test_pytest_standard_runner.py
@@ -39,22 +39,18 @@ class TestPythonStandardRunner(object):
         )
         assert result == output
 
-    @pytest.mark.parametrize(
-        "command_configured", [["pyenv", "pytest"], "pyenv pytest"]
-    )
+    @pytest.mark.parametrize("python_path", ["/usr/bin/python", "venv/bin/python"])
     @patch("codecov_cli.runners.pytest_standard_runner.subprocess")
-    def test_execute_pytest_user_provided_command(
-        self, mock_subprocess, command_configured
-    ):
+    def test_execute_pytest_user_provided_command(self, mock_subprocess, python_path):
         output = "Output in stdout"
         return_value = MagicMock(stdout=output.encode("utf-8"))
         mock_subprocess.run.return_value = return_value
 
-        runner = PytestStandardRunner(dict(pytest_command=command_configured))
+        runner = PytestStandardRunner(dict(python_path=python_path))
 
         result = runner._execute_pytest(["--option", "--ignore=batata"])
         mock_subprocess.run.assert_called_with(
-            ["pyenv", "pytest", "--option", "--ignore=batata"],
+            [python_path, "-m", "pytest", "--option", "--ignore=batata"],
             capture_output=True,
             check=True,
             stdout=None,


### PR DESCRIPTION
We add 'pytest_command' so that users can specify the pytest command to use. That is still confusing for users to setup the config. Plus people are more used to give a python path to execute.

So I think it's good idea to replace 'pytest_command' to the simpler 'python_path'.