### PR TITLE
feat+fix: preserve test collection order

### DIFF
--- a/codecov_cli/runners/pytest_standard_runner.py
+++ b/codecov_cli/runners/pytest_standard_runner.py
@@ -140,35 +140,26 @@ class PytestStandardRunner(LabelAnalysisRunnerInterface):
             f"--cov={self.params.coverage_root}",
             "--cov-context=test",
         ] + self.params.execute_tests_options
-        all_labels = set(
-            result.absent_labels
-            + result.present_diff_labels
-            + result.global_level_labels
-        )
-        skipped_tests = set(result.present_report_labels) - all_labels
-        if skipped_tests:
+        tests_to_run = result.get_tests_to_run_in_collection_order()
+        tests_to_skip = result.get_tests_to_skip_in_collection_order()
+        if tests_to_skip:
             logger.info(
                 "Some tests are being skipped. (run in verbose mode to get list of tests skipped)",
                 extra=dict(
-                    extra_log_attributes=dict(skipped_tests_count=len(skipped_tests))
+                    extra_log_attributes=dict(skipped_tests_count=len(tests_to_skip))
                 ),
             )
             logger.debug(
                 "List of skipped tests",
-                extra=dict(
-                    extra_log_attributes=dict(skipped_tests=sorted(skipped_tests))
-                ),
+                extra=dict(extra_log_attributes=dict(skipped_tests=tests_to_skip)),
             )
 
-        if len(all_labels) == 0:
-            all_labels = [random.choice(result.present_report_labels)]
+        if len(tests_to_run) == 0:
+            tests_to_run = [random.choice(result.present_report_labels)]
             logger.info(
                 "All tests are being skipped. Selected random label to run",
-                extra=dict(extra_log_attributes=dict(selected_label=all_labels[0])),
+                extra=dict(extra_log_attributes=dict(selected_label=tests_to_run[0])),
             )
-        tests_to_run = [
-            label.split("[")[0] if "[" in label else label for label in all_labels
-        ]
         command_array = default_options + tests_to_run
         logger.info(
             "Running tests. (run in verbose mode to get list of tests executed)"

--- a/codecov_cli/runners/types.py
+++ b/codecov_cli/runners/types.py
@@ -21,6 +21,34 @@ class LabelAnalysisRequestResult(dict):
     def global_level_labels(self) -> List[str]:
         return self.get("global_level_labels", [])
 
+    @property
+    def collected_labels_in_order(self) -> List[str]:
+        """The list of collected labels, in the order returned by the testing tool.
+        This is a superset of all other lists.
+        """
+        return self.get("collected_labels_in_order", [])
+
+    def get_tests_to_run_in_collection_order(self) -> List[str]:
+        labels_to_run = set(
+            self.absent_labels + self.global_level_labels + self.present_diff_labels
+        )
+        output = []
+        for test_name in self.collected_labels_in_order:
+            if test_name in labels_to_run:
+                output.append(test_name)
+        return output
+
+    def get_tests_to_skip_in_collection_order(self) -> List[str]:
+        labels_to_run = set(
+            self.absent_labels + self.global_level_labels + self.present_diff_labels
+        )
+        labels_to_skip = set(self.present_report_labels) - labels_to_run
+        output = []
+        for test_name in self.collected_labels_in_order:
+            if test_name in labels_to_skip:
+                output.append(test_name)
+        return output
+
 
 class LabelAnalysisRunnerInterface(object):
     params: Dict = None

--- a/tests/runners/test_pytest_standard_runner.py
+++ b/tests/runners/test_pytest_standard_runner.py
@@ -1,16 +1,14 @@
 from subprocess import CalledProcessError
-from unittest.mock import MagicMock, call, patch
+from unittest.mock import MagicMock, patch
 
 import click
 import pytest
-from pytest import ExitCode
 
 from codecov_cli.runners.pytest_standard_runner import (
     PytestStandardRunner,
     PytestStandardRunnerConfigParams,
 )
 from codecov_cli.runners.pytest_standard_runner import logger as runner_logger
-from codecov_cli.runners.pytest_standard_runner import stdout as pyrunner_stdout
 from codecov_cli.runners.types import LabelAnalysisRequestResult
 
 
@@ -203,6 +201,11 @@ class TestPythonStandardRunner(object):
             "absent_labels": ["test_absent"],
             "present_diff_labels": ["test_in_diff"],
             "global_level_labels": ["test_global"],
+            "collected_labels_in_order": [
+                "test_absent",
+                "test_global",
+                "test_in_diff",
+            ],
         }
         mock_execute = mocker.patch.object(PytestStandardRunner, "_execute_pytest")
 
@@ -229,6 +232,11 @@ class TestPythonStandardRunner(object):
             "absent_labels": ["test_absent"],
             "present_diff_labels": ["test_in_diff"],
             "global_level_labels": ["test_global"],
+            "collected_labels_in_order": [
+                "test_absent",
+                "test_global",
+                "test_in_diff",
+            ],
         }
         mock_execute = mocker.patch.object(PytestStandardRunner, "_execute_pytest")
 
@@ -257,6 +265,11 @@ class TestPythonStandardRunner(object):
             "absent_labels": ["test_absent"],
             "present_diff_labels": ["test_in_diff"],
             "global_level_labels": ["test_global"],
+            "collected_labels_in_order": [
+                "test_absent",
+                "test_global",
+                "test_in_diff",
+            ],
         }
         mock_execute = mocker.patch.object(PytestStandardRunner, "_execute_pytest")
         mock_warning = mocker.patch.object(runner_logger, "warning")


### PR DESCRIPTION
We run into issues with test ordering with some frequency in the ATS
step in CI. This is because ATS scrambles the test order and this
uncovers certain dependencies within tests.

Sure there's some value in doing that, but fixing these issues is
somewhat annoying and actually disrupts the workflow more than is
helpful. Scrambling test order needs to be deliberate, not accidental

These changes make sure that we preserve the order that pytest
collected tests when deciding the order to run them.

Notice that it can still run into ordering issues if a test that
depends on another test does't get picked to run.