### PR TITLE
fix: correctly generate network if path has spaces

### DIFF
--- a/codecov_cli/helpers/versioning_systems.py
+++ b/codecov_cli/helpers/versioning_systems.py
@@ -118,7 +118,7 @@ class GitVersioningSystem(VersioningSystemInterface):
             filename[1:-1]
             if filename.startswith('"') and filename.endswith('"')
             else filename
-            for filename in res.stdout.decode("unicode_escape").strip().split()
+            for filename in res.stdout.decode("unicode_escape").strip().split("\n")
         ]
 
 

--- a/tests/helpers/test_folder_searcher.py
+++ b/tests/helpers/test_folder_searcher.py
@@ -43,6 +43,7 @@ def test_search_files_with_folder_exclusion(tmp_path):
         "another/some/banana.py",
         "from/some/banana.py",
         "to/some/banana.py",
+        "path/folder with space/banana.py",
         "apple.py",
         "banana.py",
     ]
@@ -56,6 +57,7 @@ def test_search_files_with_folder_exclusion(tmp_path):
             tmp_path / "banana.py",
             tmp_path / "from/some/banana.py",
             tmp_path / "another/some/banana.py",
+            tmp_path / "path/folder with space/banana.py",
         ]
     )
     assert expected_results == sorted(

--- a/tests/helpers/test_versioning_systems.py
+++ b/tests/helpers/test_versioning_systems.py
@@ -95,7 +95,7 @@ class TestGitVersioningSystem(object):
             return_value=mocked_subprocess,
         )
         # git ls-files diplays a single \n as \\\\n
-        mocked_subprocess.stdout = b'a.txt\nb.txt\n"a\\\\nb.txt"\nc.txt\nd.txt'
+        mocked_subprocess.stdout = b'a.txt\nb.txt\n"a\\\\nb.txt"\nc.txt\nd.txt\n.circleci/config.yml\nLICENSE\napp/advanced calculations/advanced_calculator.js\n'
 
         vs = GitVersioningSystem()
 
@@ -105,6 +105,9 @@ class TestGitVersioningSystem(object):
             "a\\nb.txt",
             "c.txt",
             "d.txt",
+            ".circleci/config.yml",
+            "LICENSE",
+            "app/advanced calculations/advanced_calculator.js",
         ]
 
     def test_list_relevant_files_fails_if_no_root_is_found(self, mocker):


### PR DESCRIPTION
Parsing of output of the `ls-files` commands was splitting paths with spaces. It is literally the difference show below.

```python
>>> s = 'string space\nother line\n'
>>> s.split()
['string', 'space', 'other', 'line']
>>> s.split('\n')
['string space', 'other line', '']
```
closes: codecov/codecov-cli#356