### PR TITLE
build: don't run steps that req secrets if fork

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,7 @@ jobs:
 
   codecov-startup:
     runs-on: ubuntu-latest
+    if: ${{ !github.event.pull_request.head.repo.fork && github.repository_owner == 'codecov' }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -78,12 +79,14 @@ jobs:
       run: |
         pytest --cov
     - name: Dogfooding codecov-cli
+      if: ${{ !github.event.pull_request.head.repo.fork && github.repository_owner == 'codecov' }}
       run: |
         codecovcli do-upload --fail-on-error -t ${{ secrets.CODECOV_TOKEN }} --plugin pycoverage --flag python${{matrix.python-version}}
 
   static-analysis:
     runs-on: ubuntu-latest
     needs: codecov-startup
+    if: ${{ !github.event.pull_request.head.repo.fork && github.repository_owner == 'codecov' }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -107,6 +110,7 @@ jobs:
   label-analysis:
     runs-on: ubuntu-latest
     needs: static-analysis
+    if: ${{ !github.event.pull_request.head.repo.fork && github.repository_owner == 'codecov' }}
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,7 +51,6 @@ jobs:
 
   build-test-upload:
     runs-on: ubuntu-latest
-    needs: codecov-startup
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
we don't want to run the steps in the CI workflow that require access to secrets so that they don't block the tests from running.