### PR TITLE
fix: use sys.exit() instead of just exit()

### DIFF
--- a/codecov_cli/helpers/request.py
+++ b/codecov_cli/helpers/request.py
@@ -1,4 +1,5 @@
 import logging
+from sys import exit
 from time import sleep
 
 import click


### PR DESCRIPTION
related to: https://github.com/codecov/codecov-cli/issues/370