### PR TITLE
feat: make noop plugin recognizable

### DIFF
--- a/codecov_cli/plugins/__init__.py
+++ b/codecov_cli/plugins/__init__.py
@@ -60,6 +60,8 @@ def _load_plugin_from_yaml(plugin_dict: typing.Dict):
 
 
 def _get_plugin(cli_config, plugin_name):
+    if plugin_name == "noop":
+        return NoopPlugin()
     if plugin_name == "gcov":
         return GcovPlugin()
     if plugin_name == "pycoverage":

--- a/tests/plugins/test_instantiation.py
+++ b/tests/plugins/test_instantiation.py
@@ -115,7 +115,7 @@ def test_get_plugin_xcode():
     assert isinstance(res, XcodePlugin)
 
 
-def test_get_plugin_xcode():
+def test_get_plugin_noop():
     res = _get_plugin({}, "noop")
     assert isinstance(res, NoopPlugin)
 

--- a/tests/plugins/test_instantiation.py
+++ b/tests/plugins/test_instantiation.py
@@ -115,6 +115,11 @@ def test_get_plugin_xcode():
     assert isinstance(res, XcodePlugin)
 
 
+def test_get_plugin_xcode():
+    res = _get_plugin({}, "noop")
+    assert isinstance(res, NoopPlugin)
+
+
 def test_get_plugin_pycoverage():
     res = _get_plugin({}, "pycoverage")
     assert isinstance(res, Pycoverage)


### PR DESCRIPTION
context: https://github.com/codecov/feedback/issues/258

Currently there's no way to disable plugins.
We don't want to change the default to preserve compatibility with the uploader little magic tricks that were executed by default (as far as I know).

These changes allow you to pass the `--plugin noop` option to the `create-upload` command in order to not execute any plugin.