### PR TITLE
fix: remove typing.Optional from codecov yaml path option

### DIFF
--- a/codecov_cli/main.py
+++ b/codecov_cli/main.py
@@ -34,7 +34,7 @@ logger = logging.getLogger("codecovcli")
 )
 @click.option(
     "--codecov-yml-path",
-    type=click.Path(path_type=typing.Optional[pathlib.Path]),
+    type=click.Path(path_type=pathlib.Path),
     default=None,
 )
 @click.option(


### PR DESCRIPTION
just want to quickly solve this: https://github.com/codecov/feedback/issues/259, I don't think we can use `typing.Optional` in either the `type` field in the `click.option` decorator or the `path_type` field in the `click.Path` class