### PR TITLE
Define git_service config getter for Github actions

### DIFF
--- a/codecov_cli/helpers/ci_adapters/github_actions.py
+++ b/codecov_cli/helpers/ci_adapters/github_actions.py
@@ -86,5 +86,8 @@ class GithubActionsCIAdapter(CIAdapterBase):
     def _get_service(self):
         return "github-actions"
 
+    def _get_git_service(self):
+        return "github"
+
     def get_service_name(self):
         return "GithubActions"


### PR DESCRIPTION
This is my attempt at fixing the issue https://github.com/google/mdbook-i18n-helpers/issues/173.

I am not very familiar with this codebase but I think it might fix the issue.

My Github workflows implements an unusual technique for codecov uploads which I described in [this thread](https://github.com/codecov/feedback/issues/126#issuecomment-1924413592).

It used to work in `codecov-action` v3 and stopped working in v4. The error I am getting is `Commit creating failed: ["Service not found: none"]`.

I suspect this is due to missing implementation of [`_get_git_service`](https://github.com/codecov/codecov-cli/blob/5d309ec1694c7853a06ed5f8b04a63f8705a5880/codecov_cli/helpers/ci_adapters/base.py#L101-L102) in [`github_actions.py`](https://github.com/codecov/codecov-cli/blob/5d309ec1694c7853a06ed5f8b04a63f8705a5880/codecov_cli/helpers/ci_adapters/github_actions.py).
