### PR TITLE
fix: update user file search

### DIFF
--- a/codecov_cli/services/upload/file_finder.py
+++ b/codecov_cli/services/upload/file_finder.py
@@ -180,13 +180,13 @@ default_folders_to_ignore = [
 class FileFinder(object):
     def __init__(
         self,
-        project_root: Path = None,
+        search_root: Path = None,
         folders_to_ignore: typing.List[str] = None,
         explicitly_listed_files: typing.List[Path] = None,
         disable_search: bool = False,
         report_type: str = "coverage",
     ):
-        self.project_root = project_root or Path(os.getcwd())
+        self.search_root = search_root or Path(os.getcwd())
         self.folders_to_ignore = folders_to_ignore or []
         self.explicitly_listed_files = explicitly_listed_files or None
         self.disable_search = disable_search
@@ -207,7 +207,7 @@ class FileFinder(object):
         if not self.disable_search:
             regex_patterns_to_include = globs_to_regex(files_patterns)
             files_paths = search_files(
-                self.project_root,
+                self.search_root,
                 default_folders_to_ignore + self.folders_to_ignore,
                 filename_include_regex=regex_patterns_to_include,
                 filename_exclude_regex=regex_patterns_to_exclude,
@@ -243,16 +243,17 @@ class FileFinder(object):
         )
         user_files_paths = list(
             search_files(
-                self.project_root,
-                default_folders_to_ignore + self.folders_to_ignore,
+                self.search_root,
+                self.folders_to_ignore,
                 filename_include_regex=regex_patterns_to_include,
                 filename_exclude_regex=regex_patterns_to_exclude,
                 multipart_include_regex=multipart_include_regex,
             )
         )
         not_found_files = []
+        user_files_paths_resolved = [path.resolve() for path in user_files_paths]
         for filepath in self.explicitly_listed_files:
-            if filepath.resolve() not in user_files_paths:
+            if filepath.resolve() not in user_files_paths_resolved:
                 not_found_files.append(filepath)
 
         if not_found_files:

--- a/tests/services/upload/test_coverage_file_finder.py
+++ b/tests/services/upload/test_coverage_file_finder.py
@@ -179,8 +179,10 @@ class TestCoverageFileFinderUserInput(unittest.TestCase):
             self.project_root / "coverage.xml",
             self.project_root / "subdirectory" / "test_coverage.xml",
             self.project_root / "other_file.txt",
+            self.project_root / ".tox" / "another_file.abc",
         ]
         (self.project_root / "subdirectory").mkdir()
+        (self.project_root / ".tox").mkdir()
         for file in coverage_files:
             file.touch()
 
@@ -208,8 +210,10 @@ class TestCoverageFileFinderUserInput(unittest.TestCase):
             self.project_root / "subdirectory" / "another_file.abc",
             self.project_root / "subdirectory" / "test_coverage.xml",
             self.project_root / "other_file.txt",
+            self.project_root / ".tox" / "another_file.abc",
         ]
         (self.project_root / "subdirectory").mkdir()
+        (self.project_root / ".tox").mkdir()
         for file in coverage_files:
             file.touch()
 
@@ -237,8 +241,10 @@ class TestCoverageFileFinderUserInput(unittest.TestCase):
             self.project_root / "subdirectory" / "test_coverage.xml",
             self.project_root / "test_file.abc",
             self.project_root / "subdirectory" / "another_file.abc",
+            self.project_root / ".tox" / "another_file.abc",
         ]
         (self.project_root / "subdirectory").mkdir()
+        (self.project_root / ".tox").mkdir()
         for file in coverage_files:
             file.touch()
 
@@ -264,8 +270,10 @@ class TestCoverageFileFinderUserInput(unittest.TestCase):
         coverage_files = [
             self.project_root / "coverage.xml",
             self.project_root / "subdirectory" / "test_coverage.xml",
+            self.project_root / ".tox" / "another_file.abc",
         ]
         (self.project_root / "subdirectory").mkdir()
+        (self.project_root / ".tox").mkdir()
         for file in coverage_files:
             file.touch()
 
@@ -282,6 +290,39 @@ class TestCoverageFileFinderUserInput(unittest.TestCase):
             UploadCollectionResultFile(Path(f"{self.project_root}/coverage.xml")),
             UploadCollectionResultFile(
                 Path(f"{self.project_root}/subdirectory/test_coverage.xml")
+            ),
+        ]
+        expected_paths = sorted([file.get_filename() for file in expected])
+        self.assertEqual(result, expected_paths)
+
+    def test_find_coverage_files_with_user_specified_files_in_default_ignored_folder(self):
+        # Create some sample coverage files
+        coverage_files = [
+            self.project_root / "coverage.xml",
+            self.project_root / "subdirectory" / "test_coverage.xml",
+            self.project_root / "test_file.abc",
+            self.project_root / "subdirectory" / "another_file.abc",
+            self.project_root / ".tox" / "another_file.abc",
+        ]
+        (self.project_root / "subdirectory").mkdir()
+        (self.project_root / ".tox").mkdir()
+        for file in coverage_files:
+            file.touch()
+
+        self.coverage_file_finder.explicitly_listed_files = [
+            self.project_root / ".tox" / "another_file.abc",
+        ]
+        result = sorted(
+            [file.get_filename() for file in self.coverage_file_finder.find_files()]
+        )
+
+        expected = [
+            UploadCollectionResultFile(Path(f"{self.project_root}/coverage.xml")),
+            UploadCollectionResultFile(
+                Path(f"{self.project_root}/subdirectory/test_coverage.xml")
+            ),
+            UploadCollectionResultFile(
+                Path(f"{self.project_root}/.tox/another_file.abc")
             ),
         ]
         expected_paths = sorted([file.get_filename() for file in expected])


### PR DESCRIPTION
fixes https://github.com/codecov/feedback/issues/84

This PR does 3 things

1. Rename `project_root` to `search_root` to make it more maintainable and understandable
2. Remove the restriction on certain folders when searching for a user-given string. **Unknown**: how this may affect performance for large repositories. Would love insight here, but it shouldn't degrade that poorly. It's all `os.walk`
3. Compare the user resolved paths to resolved found paths. This is an apples to apples match which would fail beforehand if the user didn't give full pathing (vs relative to root)