### PR TITLE
fix: better detect merge-commits

### DIFF
--- a/codecov_cli/helpers/versioning_systems.py
+++ b/codecov_cli/helpers/versioning_systems.py
@@ -42,6 +42,20 @@ class GitVersioningSystem(VersioningSystemInterface):
 
     def get_fallback_value(self, fallback_field: FallbackFieldEnum):
         if fallback_field == FallbackFieldEnum.commit_sha:
+            # here we will get the commit SHA of the latest commit
+            # that is NOT a merge commit
+            p = subprocess.run(
+                # List current commit parent's SHA
+                ["git", "rev-parse", "HEAD^@"],
+                capture_output=True,
+            )
+            parents_hash = p.stdout.decode().strip().splitlines()
+            if len(parents_hash) == 2:
+                # IFF the current commit is a merge commit it will have 2 parents
+                # We return the 2nd one - The commit that came from the branch merged into ours
+                return parents_hash[1]
+            # At this point we know the current commit is not a merge commit
+            # so we get it's SHA and return that
             p = subprocess.run(["git", "log", "-1", "--format=%H"], capture_output=True)
             if p.stdout:
                 return p.stdout.decode().strip()
@@ -56,7 +70,7 @@ class GitVersioningSystem(VersioningSystemInterface):
                 return branch_name if branch_name != "HEAD" else None
 
         if fallback_field == FallbackFieldEnum.slug:
-            # if there are multiple remotes, we will prioritize using the one called 'origin' if it exsits, else we will use the first one in 'git remote' list
+            # if there are multiple remotes, we will prioritize using the one called 'origin' if it exists, else we will use the first one in 'git remote' list
 
             p = subprocess.run(["git", "remote"], capture_output=True)
 
@@ -78,7 +92,7 @@ class GitVersioningSystem(VersioningSystemInterface):
             return parse_slug(remote_url)
 
         if fallback_field == FallbackFieldEnum.git_service:
-            # if there are multiple remotes, we will prioritize using the one called 'origin' if it exsits, else we will use the first one in 'git remote' list
+            # if there are multiple remotes, we will prioritize using the one called 'origin' if it exists, else we will use the first one in 'git remote' list
 
             p = subprocess.run(["git", "remote"], capture_output=True)
             if not p.stdout:

--- a/tests/services/upload/test_coverage_file_finder.py
+++ b/tests/services/upload/test_coverage_file_finder.py
@@ -295,7 +295,9 @@ class TestCoverageFileFinderUserInput(unittest.TestCase):
         expected_paths = sorted([file.get_filename() for file in expected])
         self.assertEqual(result, expected_paths)
 
-    def test_find_coverage_files_with_user_specified_files_in_default_ignored_folder(self):
+    def test_find_coverage_files_with_user_specified_files_in_default_ignored_folder(
+        self,
+    ):
         # Create some sample coverage files
         coverage_files = [
             self.project_root / "coverage.xml",


### PR DESCRIPTION
Apparently a common thing for CIs to do is create a merge-commit for changes
in a branch before running tests and stuff.
This means that - especially for not-directly-supported CIs - we would maybe
return a SHA for a commit that didn't exist in the branch.

These changes fix that by checking to see if the current commit is a merge commit.
If it is we return the second parent, the most recent commit before the current one.

Q: What if the current latest commit in the branch is a merge commit?
Well in this case the parent, which is also part of the branch, will have the coverage.

Users can still provide a commit sha value to override this behavior.

closes codecov/codecov-cli#372