### PR TITLE
Fix compatibility on non-git project folders when git is installed on the system

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ Codecov-cli supports user input. These inputs, along with their descriptions and
 | `get-report-results` | Used for local upload. It asks codecov to provide you the report results you calculated with the previous command. 
 | `pr-base-picking` | Tells codecov that you want to explicitly define a base for your PR
 | `upload-process` | A wrapper for 3 commands. Create-commit, create-report and do-upload. You can use this command to upload to codecov instead of using the previosly mentioned commands.
-| `send-notification` | A command that tells Codecov that you finished uploading and you want to be sent notifications. To disable automatically sent notifications please consider adding manual_trigger to your codecov.yml, so it will look like codecov: notify: manual_trigger: true. 
+| `send-notifications` | A command that tells Codecov that you finished uploading and you want to be sent notifications. To disable automatically sent notifications please consider adding manual_trigger to your codecov.yml, so it will look like codecov: notify: manual_trigger: true.
 >**Note**: Every command has its own different options that will be mentioned later in this doc. Codecov will try to load these options from your CI environment variables, if not, it will try to load them from git, if not found, you may need to add them manually. 
 
 

--- a/codecov_cli/helpers/versioning_systems.py
+++ b/codecov_cli/helpers/versioning_systems.py
@@ -38,7 +38,13 @@ def get_versioning_system() -> VersioningSystemInterface:
 class GitVersioningSystem(VersioningSystemInterface):
     @classmethod
     def is_available(cls):
-        return which("git") is not None
+        if which("git") is not None:
+            p = subprocess.run(
+                ["git", "rev-parse", "--show-toplevel"], capture_output=True
+            )
+            if p.stdout:
+                return True
+        return False
 
     def get_fallback_value(self, fallback_field: FallbackFieldEnum):
         if fallback_field == FallbackFieldEnum.commit_sha:


### PR DESCRIPTION
Hi, I'm not a python person so not sure best way to add test coverage for this, but to kick off a discussion here's the code change.

We run our CI through Jenkins, and to support job fanout our build process involves doing a git checkout on one node, caching the application files, and then subsequent nodes will restore code from that cache and run a subset of our tests. (We currently have a job fanout of around 50.) To reduce the size of the cached blob, we are excluding our .git folder from the cache.

This leads to us hitting a problem uploading our coverage files, because the GitVersioningSystem:

- says it `is_available` if git is installed on the system (which it is because we reuse our worker base images)
- in `get_network_root` it fails because `git rev-parse --show-toplevel` is erroring out `fatal: not a git repository`
- in `list_relevant_files` it therefore raises `Can't determine root folder` and blows up the stack:

```
<snip>
  File "/home/deploy/.local/lib/python3.7/site-packages/codecov_cli/commands/upload.py", line 256, in do_upload
    handle_no_reports_found=handle_no_reports_found,
  File "/home/deploy/.local/lib/python3.7/site-packages/codecov_cli/services/upload/__init__.py", line 66, in do_upload_logic
    upload_data = collector.generate_upload_data()
  File "/home/deploy/.local/lib/python3.7/site-packages/codecov_cli/services/upload/upload_collector.py", line 145, in generate_upload_data
    network = self.network_finder.find_files()
  File "/home/deploy/.local/lib/python3.7/site-packages/codecov_cli/services/upload/network_finder.py", line 17, in find_files
    return self.versioning_system.list_relevant_files(network_root)
  File "/home/deploy/.local/lib/python3.7/site-packages/codecov_cli/helpers/versioning_systems.py", line 111, in list_relevant_files
    raise ValueError("Can't determine root folder")
ValueError: Can't determine root folder
```

I'm _Patching It Live_ (thanks for the perl oneliner help, ChatGPT) to get it working for us, and can confirm that this change does successfully prevent GitVersioningSystem from being used, and NoVersioningSystem is treating us fine with just the `Path.cwd()` check. 
