### PR TITLE
fix: log info if a file shows up as a directory

### DIFF
--- a/codecov_cli/helpers/folder_searcher.py
+++ b/codecov_cli/helpers/folder_searcher.py
@@ -58,7 +58,7 @@ def search_files(
     this_is_excluded = functools.partial(
         _is_excluded, filename_exclude_regex, multipart_exclude_regex
     )
-    for (dirpath, dirnames, filenames) in os.walk(folder_to_search):
+    for dirpath, dirnames, filenames in os.walk(folder_to_search):
         dirs_to_remove = set(d for d in dirnames if d in folders_to_ignore)
 
         if multipart_exclude_regex is not None:

--- a/codecov_cli/helpers/git_services/github.py
+++ b/codecov_cli/helpers/git_services/github.py
@@ -24,9 +24,11 @@ class Github:
                     "ref": res["head"]["ref"],
                     # Through empiric test data it seems that the "repo" key in "head" is set to None
                     # If the PR is from the same repo (e.g. not from a fork)
-                    "slug": res["head"]["repo"]["full_name"]
-                    if res["head"]["repo"]
-                    else res["base"]["repo"]["full_name"],
+                    "slug": (
+                        res["head"]["repo"]["full_name"]
+                        if res["head"]["repo"]
+                        else res["base"]["repo"]["full_name"]
+                    ),
                 },
                 "base": {
                     "sha": res["base"]["sha"],

--- a/codecov_cli/helpers/request.py
+++ b/codecov_cli/helpers/request.py
@@ -47,7 +47,8 @@ def backoff_time(curr_retry):
     return 2 ** (curr_retry - 1)
 
 
-class RetryException(Exception): ...
+class RetryException(Exception):
+    ...
 
 
 def retry_request(func):

--- a/codecov_cli/helpers/request.py
+++ b/codecov_cli/helpers/request.py
@@ -47,8 +47,7 @@ def backoff_time(curr_retry):
     return 2 ** (curr_retry - 1)
 
 
-class RetryException(Exception):
-    ...
+class RetryException(Exception): ...
 
 
 def retry_request(func):

--- a/codecov_cli/helpers/versioning_systems.py
+++ b/codecov_cli/helpers/versioning_systems.py
@@ -135,9 +135,11 @@ class GitVersioningSystem(VersioningSystemInterface):
         )
 
         return [
-            filename[1:-1]
-            if filename.startswith('"') and filename.endswith('"')
-            else filename
+            (
+                filename[1:-1]
+                if filename.startswith('"') and filename.endswith('"')
+                else filename
+            )
             for filename in res.stdout.decode("unicode_escape").strip().split("\n")
         ]
 

--- a/codecov_cli/services/staticanalysis/analyzers/general.py
+++ b/codecov_cli/services/staticanalysis/analyzers/general.py
@@ -85,13 +85,13 @@ class BaseAnalyzer(object):
 
     def get_import_lines(self, root_node, imports_query):
         import_lines = set()
-        for (a, _) in imports_query.captures(root_node):
+        for a, _ in imports_query.captures(root_node):
             import_lines.add((a.start_point[0] + 1, a.end_point[0] - a.start_point[0]))
         return import_lines
 
     def get_definition_lines(self, root_node, definitions_query):
         definition_lines = set()
-        for (a, _) in definitions_query.captures(root_node):
+        for a, _ in definitions_query.captures(root_node):
             definition_lines.add(
                 (a.start_point[0] + 1, a.end_point[0] - a.start_point[0])
             )

--- a/codecov_cli/services/upload/upload_collector.py
+++ b/codecov_cli/services/upload/upload_collector.py
@@ -140,9 +140,7 @@ class UploadCollector(object):
                 ),
             )
         except IsADirectoryError as err:
-            logger.info(
-                f"Skipping {filename}, is a directory not a file"
-            )
+            logger.info(f"Skipping {filename}, found a directory not a file")
 
         return UploadCollectionResultFileFixer(
             path, fixed_lines_without_reason, fixed_lines_with_reason, eof

--- a/codecov_cli/services/upload/upload_collector.py
+++ b/codecov_cli/services/upload/upload_collector.py
@@ -139,6 +139,10 @@ class UploadCollector(object):
                     reason=err.reason,
                 ),
             )
+        except IsADirectoryError as err:
+            logger.info(
+                f"Skipping {filename}, is a directory not a file"
+            )
 
         return UploadCollectionResultFileFixer(
             path, fixed_lines_without_reason, fixed_lines_with_reason, eof


### PR DESCRIPTION
fixes https://github.com/codecov/codecov-action/issues/1303

`git ls-files` will pull submodules as files, this change just logs that a file shows up as such a directory and continues on