### PR TITLE
feat: adjust for tokenless v3

### DIFF
--- a/codecov_cli/commands/report.py
+++ b/codecov_cli/commands/report.py
@@ -13,6 +13,15 @@ logger = logging.getLogger("codecovcli")
 @click.option(
     "--code", help="The code of the report. If unsure, leave default", default="default"
 )
+@click.option(
+    "-P",
+    "--pr",
+    "--pull-request-number",
+    "pull_request_number",
+    help="Deprecated option, this option has no effect on the execution of this command anymore. Specify the pull request number mannually. Used to override pre-existing CI environment variables",
+    cls=CodecovOption,
+    fallback_field=FallbackFieldEnum.pull_request_number,
+)
 @global_options
 @click.pass_context
 def create_report(
@@ -23,6 +32,7 @@ def create_report(
     git_service: str,
     token: str,
     fail_on_error: bool,
+    pull_request_number: int,
 ):
     enterprise_url = ctx.obj.get("enterprise_url")
     logger.debug(

--- a/codecov_cli/commands/report.py
+++ b/codecov_cli/commands/report.py
@@ -13,15 +13,6 @@ logger = logging.getLogger("codecovcli")
 @click.option(
     "--code", help="The code of the report. If unsure, leave default", default="default"
 )
-@click.option(
-    "-P",
-    "--pr",
-    "--pull-request-number",
-    "pull_request_number",
-    help="Specify the pull request number mannually. Used to override pre-existing CI environment variables",
-    cls=CodecovOption,
-    fallback_field=FallbackFieldEnum.pull_request_number,
-)
 @global_options
 @click.pass_context
 def create_report(
@@ -32,7 +23,6 @@ def create_report(
     git_service: str,
     token: str,
     fail_on_error: bool,
-    pull_request_number: int,
 ):
     enterprise_url = ctx.obj.get("enterprise_url")
     logger.debug(
@@ -55,7 +45,6 @@ def create_report(
         git_service,
         token,
         enterprise_url,
-        pull_request_number,
         fail_on_error,
     )
     if not res.error:

--- a/codecov_cli/commands/report.py
+++ b/codecov_cli/commands/report.py
@@ -18,7 +18,7 @@ logger = logging.getLogger("codecovcli")
     "--pr",
     "--pull-request-number",
     "pull_request_number",
-    help="Deprecated option, this option has no effect on the execution of this command anymore. Specify the pull request number mannually. Used to override pre-existing CI environment variables",
+    help="[Deprecated], this option has no effect on the execution of this command anymore. Specify the pull request number mannually. Used to override pre-existing CI environment variables",
     cls=CodecovOption,
     fallback_field=FallbackFieldEnum.pull_request_number,
 )

--- a/codecov_cli/helpers/request.py
+++ b/codecov_cli/helpers/request.py
@@ -1,4 +1,5 @@
 import logging
+import os
 from sys import exit
 from time import sleep
 
@@ -93,6 +94,15 @@ def get_token_header_or_fail(token: str) -> dict:
             "Codecov token not found. Please provide Codecov token with -t flag."
         )
     return {"Authorization": f"token {token}"}
+
+
+def get_auth_header(token):
+    tokenless = os.environ.get("TOKENLESS", None)
+    if tokenless:
+        headers = {"X-Tokenless": tokenless}
+    else:
+        headers = get_token_header_or_fail(token)
+    return headers
 
 
 @retry_request

--- a/codecov_cli/services/commit/__init__.py
+++ b/codecov_cli/services/commit/__init__.py
@@ -2,10 +2,9 @@ import logging
 import typing
 
 from codecov_cli.helpers.config import CODECOV_API_URL
-from codecov_cli.helpers.encoder import decode_slug, encode_slug
-from codecov_cli.helpers.git import get_pull, is_fork_pr
+from codecov_cli.helpers.encoder import encode_slug
 from codecov_cli.helpers.request import (
-    get_token_header_or_fail,
+    get_auth_header,
     log_warnings_and_errors_if_any,
     send_post_request,
 )
@@ -43,15 +42,7 @@ def create_commit_logic(
 def send_commit_data(
     commit_sha, parent_sha, pr, branch, slug, token, service, enterprise_url
 ):
-    decoded_slug = decode_slug(slug)
-    pull_dict = get_pull(service, decoded_slug, pr) if not token else None
-    if is_fork_pr(pull_dict):
-        headers = {"X-Tokenless": pull_dict["head"]["slug"], "X-Tokenless-PR": pr}
-        branch = pull_dict["head"]["slug"] + ":" + branch
-        logger.info("The PR is happening in a forked repo. Using tokenless upload.")
-    else:
-        headers = get_token_header_or_fail(token)
-
+    headers = get_auth_header(token)
     data = {
         "commitid": commit_sha,
         "parent_commit_id": parent_sha,

--- a/tests/commands/test_process_test_results.py
+++ b/tests/commands/test_process_test_results.py
@@ -44,7 +44,6 @@ def test_process_test_results(
 
     assert result.exit_code == 0
 
-
     mocked_post.assert_called_with(
         url="https://api.github.com/repos/fake/repo/issues/pull/comments",
         data={
@@ -56,7 +55,6 @@ def test_process_test_results(
             "X-GitHub-Api-Version": "2022-11-28",
         },
     )
-
 
 
 def test_process_test_results_non_existent_file(mocker, tmpdir):
@@ -93,7 +91,7 @@ def test_process_test_results_non_existent_file(mocker, tmpdir):
     assert result.exit_code == 1
     expected_logs = [
         "ci service found",
-        'Some files were not found',
+        "Some files were not found",
     ]
     for log in expected_logs:
         assert log in result.output
@@ -180,7 +178,6 @@ def test_process_test_results_missing_ref(mocker, tmpdir):
     ]
     for log in expected_logs:
         assert log in result.output
-
 
 
 def test_process_test_results_missing_step_summary(mocker, tmpdir):

--- a/tests/helpers/test_network_finder.py
+++ b/tests/helpers/test_network_finder.py
@@ -12,10 +12,35 @@ def test_find_files(mocker, tmp_path):
     mocked_vs = MagicMock()
     mocked_vs.list_relevant_files.return_value = filenames
 
-    assert NetworkFinder(versioning_system=mocked_vs, network_filter=None, network_prefix=None, network_root_folder=tmp_path).find_files() == filenames
-    assert NetworkFinder(versioning_system=mocked_vs, network_filter="hello", network_prefix="bello", network_root_folder=tmp_path).find_files(False) == filtered_filenames
-    assert NetworkFinder(versioning_system=mocked_vs, network_filter="hello", network_prefix="bello", network_root_folder=tmp_path).find_files(True) == filenames
+    assert (
+        NetworkFinder(
+            versioning_system=mocked_vs,
+            network_filter=None,
+            network_prefix=None,
+            network_root_folder=tmp_path,
+        ).find_files()
+        == filenames
+    )
+    assert (
+        NetworkFinder(
+            versioning_system=mocked_vs,
+            network_filter="hello",
+            network_prefix="bello",
+            network_root_folder=tmp_path,
+        ).find_files(False)
+        == filtered_filenames
+    )
+    assert (
+        NetworkFinder(
+            versioning_system=mocked_vs,
+            network_filter="hello",
+            network_prefix="bello",
+            network_root_folder=tmp_path,
+        ).find_files(True)
+        == filenames
+    )
     mocked_vs.list_relevant_files.assert_called_with(tmp_path)
+
 
 def test_find_files_with_filter(mocker, tmp_path):
     filenames = ["hello/a.txt", "hello/c.txt", "bello/b.txt"]
@@ -24,9 +49,26 @@ def test_find_files_with_filter(mocker, tmp_path):
     mocked_vs = MagicMock()
     mocked_vs.list_relevant_files.return_value = filenames
 
-    assert NetworkFinder(versioning_system=mocked_vs, network_filter="hello", network_prefix=None, network_root_folder=tmp_path).find_files() == filtered_filenames
-    assert NetworkFinder(versioning_system=mocked_vs, network_filter="hello", network_prefix="bello", network_root_folder=tmp_path).find_files(True) == filenames
+    assert (
+        NetworkFinder(
+            versioning_system=mocked_vs,
+            network_filter="hello",
+            network_prefix=None,
+            network_root_folder=tmp_path,
+        ).find_files()
+        == filtered_filenames
+    )
+    assert (
+        NetworkFinder(
+            versioning_system=mocked_vs,
+            network_filter="hello",
+            network_prefix="bello",
+            network_root_folder=tmp_path,
+        ).find_files(True)
+        == filenames
+    )
     mocked_vs.list_relevant_files.assert_called_with(tmp_path)
+
 
 def test_find_files_with_prefix(mocker, tmp_path):
     filenames = ["hello/a.txt", "hello/c.txt", "bello/b.txt"]
@@ -35,9 +77,26 @@ def test_find_files_with_prefix(mocker, tmp_path):
     mocked_vs = MagicMock()
     mocked_vs.list_relevant_files.return_value = filenames
 
-    assert NetworkFinder(versioning_system=mocked_vs, network_filter=None, network_prefix="hello", network_root_folder=tmp_path).find_files() == filtered_filenames
-    assert NetworkFinder(versioning_system=mocked_vs, network_filter="hello", network_prefix="bello", network_root_folder=tmp_path).find_files(True) == filenames
+    assert (
+        NetworkFinder(
+            versioning_system=mocked_vs,
+            network_filter=None,
+            network_prefix="hello",
+            network_root_folder=tmp_path,
+        ).find_files()
+        == filtered_filenames
+    )
+    assert (
+        NetworkFinder(
+            versioning_system=mocked_vs,
+            network_filter="hello",
+            network_prefix="bello",
+            network_root_folder=tmp_path,
+        ).find_files(True)
+        == filenames
+    )
     mocked_vs.list_relevant_files.assert_called_with(tmp_path)
+
 
 def test_find_files_with_filter_and_prefix(mocker, tmp_path):
     filenames = ["hello/a.txt", "hello/c.txt", "bello/b.txt"]
@@ -46,6 +105,22 @@ def test_find_files_with_filter_and_prefix(mocker, tmp_path):
     mocked_vs = MagicMock()
     mocked_vs.list_relevant_files.return_value = filenames
 
-    assert NetworkFinder(versioning_system=mocked_vs, network_filter="hello", network_prefix="bello", network_root_folder=tmp_path).find_files() == filtered_filenames
-    assert NetworkFinder(versioning_system=mocked_vs, network_filter="hello", network_prefix="bello", network_root_folder=tmp_path).find_files(True) == filenames
+    assert (
+        NetworkFinder(
+            versioning_system=mocked_vs,
+            network_filter="hello",
+            network_prefix="bello",
+            network_root_folder=tmp_path,
+        ).find_files()
+        == filtered_filenames
+    )
+    assert (
+        NetworkFinder(
+            versioning_system=mocked_vs,
+            network_filter="hello",
+            network_prefix="bello",
+            network_root_folder=tmp_path,
+        ).find_files(True)
+        == filenames
+    )
     mocked_vs.list_relevant_files.assert_called_with(tmp_path)

--- a/tests/helpers/test_upload_sender.py
+++ b/tests/helpers/test_upload_sender.py
@@ -1,4 +1,5 @@
 import json
+import os
 import re
 from pathlib import Path
 
@@ -231,19 +232,13 @@ class TestUploadSender(object):
         mocked_storage_server,
         mocker,
     ):
-        headers = {"X-Tokenless": "user-forked/repo", "X-Tokenless-PR": "pr"}
-        mock_get_pull = mocker.patch(
-            "codecov_cli.services.upload.upload_sender.get_pull",
-            return_value={
-                "head": {"slug": "user-forked/repo"},
-                "base": {"slug": "org/repo"},
-            },
-        )
+        headers = {"X-Tokenless": "user:branch"}
         mocked_legacy_upload_endpoint.match = [
             matchers.json_params_matcher(request_data),
             matchers.header_matcher(headers),
         ]
 
+        os.environ["TOKENLESS"] = "user:branch"
         sending_result = UploadSender().send_upload_data(
             upload_collection, random_sha, None, **named_upload_data
         )
@@ -263,7 +258,6 @@ class TestUploadSender(object):
         assert (
             post_req_made.headers.items() >= headers.items()
         )  # test dict is a subset of the other
-        mock_get_pull.assert_called()
 
     def test_upload_sender_put_called_with_right_parameters(
         self, mocked_responses, mocked_legacy_upload_endpoint, mocked_storage_server

--- a/tests/services/commit/test_commit_service.py
+++ b/tests/services/commit/test_commit_service.py
@@ -1,4 +1,5 @@
 import json
+import os
 import uuid
 
 import requests
@@ -177,6 +178,8 @@ def test_commit_sender_with_forked_repo(mocker):
         "get",
         side_effect=mock_request,
     )
+
+    os.environ["TOKENLESS"] = "user:branch"
     res = send_commit_data(
         "commit_sha",
         "parent_sha",
@@ -193,7 +196,7 @@ def test_commit_sender_with_forked_repo(mocker):
             "commitid": "commit_sha",
             "parent_commit_id": "parent_sha",
             "pullid": "1",
-            "branch": "user_forked_repo/codecov-cli:branch",
+            "branch": "branch",
         },
-        headers={"X-Tokenless": "user_forked_repo/codecov-cli", "X-Tokenless-PR": "1"},
+        headers={"X-Tokenless": "user:branch"},
     )

--- a/tests/services/upload/test_upload_service.py
+++ b/tests/services/upload/test_upload_service.py
@@ -83,7 +83,12 @@ def test_do_upload_logic_happy_path_legacy_uploader(mocker):
         cli_config, ["first_plugin", "another", "forth"]
     )
     mock_select_file_finder.assert_called_with(None, None, None, False, "coverage")
-    mock_select_network_finder.assert_called_with(versioning_system, network_filter=None, network_prefix=None, network_root_folder=None)
+    mock_select_network_finder.assert_called_with(
+        versioning_system,
+        network_filter=None,
+        network_prefix=None,
+        network_root_folder=None,
+    )
     mock_generate_upload_data.assert_called_with("coverage")
     mock_send_upload_data.assert_called_with(
         mock_generate_upload_data.return_value,
@@ -172,7 +177,12 @@ def test_do_upload_logic_happy_path(mocker):
         cli_config, ["first_plugin", "another", "forth"]
     )
     mock_select_file_finder.assert_called_with(None, None, None, False, "coverage")
-    mock_select_network_finder.assert_called_with(versioning_system, network_filter=None, network_prefix=None, network_root_folder=None)
+    mock_select_network_finder.assert_called_with(
+        versioning_system,
+        network_filter=None,
+        network_prefix=None,
+        network_root_folder=None,
+    )
     mock_generate_upload_data.assert_called_with("coverage")
     mock_send_upload_data.assert_called_with(
         mock_generate_upload_data.return_value,
@@ -248,7 +258,12 @@ def test_do_upload_logic_dry_run(mocker):
         )
     out_bytes = parse_outstreams_into_log_lines(outstreams[0].getvalue())
     mock_select_file_finder.assert_called_with(None, None, None, False, "coverage")
-    mock_select_network_finder.assert_called_with(versioning_system, network_filter=None, network_prefix=None, network_root_folder=None)
+    mock_select_network_finder.assert_called_with(
+        versioning_system,
+        network_filter=None,
+        network_prefix=None,
+        network_root_folder=None,
+    )
     assert mock_generate_upload_data.call_count == 1
     assert mock_send_upload_data.call_count == 0
     mock_select_preparation_plugins.assert_called_with(
@@ -403,7 +418,12 @@ def test_do_upload_no_cov_reports_found(mocker):
         cli_config, ["first_plugin", "another", "forth"]
     )
     mock_select_file_finder.assert_called_with(None, None, None, False, "coverage")
-    mock_select_network_finder.assert_called_with(versioning_system, network_filter=None, network_prefix=None, network_root_folder=None)
+    mock_select_network_finder.assert_called_with(
+        versioning_system,
+        network_filter=None,
+        network_prefix=None,
+        network_root_folder=None,
+    )
     mock_generate_upload_data.assert_called_with("coverage")
     mock_upload_completion_call.assert_called_with(
         commit_sha="commit_sha",
@@ -477,7 +497,12 @@ def test_do_upload_rase_no_cov_reports_found_error(mocker):
         cli_config, ["first_plugin", "another", "forth"]
     )
     mock_select_file_finder.assert_called_with(None, None, None, False, "coverage")
-    mock_select_network_finder.assert_called_with(versioning_system, network_filter=None, network_prefix=None, network_root_folder=None)
+    mock_select_network_finder.assert_called_with(
+        versioning_system,
+        network_filter=None,
+        network_prefix=None,
+        network_root_folder=None,
+    )
     mock_generate_upload_data.assert_called_with("coverage")
 
 
@@ -545,7 +570,12 @@ def test_do_upload_logic_happy_path_test_results(mocker):
     assert res == UploadSender.send_upload_data.return_value
     mock_select_preparation_plugins.assert_not_called
     mock_select_file_finder.assert_called_with(None, None, None, False, "test_results")
-    mock_select_network_finder.assert_called_with(versioning_system, network_filter="some_dir", network_prefix="hello/", network_root_folder="root/")
+    mock_select_network_finder.assert_called_with(
+        versioning_system,
+        network_filter="some_dir",
+        network_prefix="hello/",
+        network_root_folder="root/",
+    )
     mock_generate_upload_data.assert_called_with("test_results")
     mock_send_upload_data.assert_called_with(
         mock_generate_upload_data.return_value,


### PR DESCRIPTION
we are no longer sending the X-Tokenless-PR header and we are changing the format of the contents of the X-Tokenless header

The X-Tokenless header will now be set to `<fork user name>:<branch name>` and will be the only extra header we send for tokenless requests. We get the value of this header from the TOKENLESS environment variable that will be set by the Codecov action.