### PR TITLE
Add additional `codecov` entrypoint

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -31,6 +31,7 @@ setup(
     ],
     entry_points={
         "console_scripts": [
+            "codecov = codecov_cli.main:run",
             "codecovcli = codecov_cli.main:run",
         ],
     },


### PR DESCRIPTION
💁 Hello team, thank you for creating this project.

Given that the https://github.com/codecov/codecov-python repository was archived last year and the associated `codecov` Python package was deprecated at the same time, adding `codecov` as an entrypoint would make this Python package's script names more aligned to the other, operating system specific, binary executables which are created from the same code. This change would also make life easier for anyone who may want to package this project as part of a software distribution like Homebrew.