### PR TITLE
support python 3.12

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,10 +35,9 @@ jobs:
         with:
           submodules: true
           fetch-depth: 2
-      - uses: actions/setup-python@v3
+      - uses: actions/setup-python@v5
         with:
-          # Because of https://github.com/tree-sitter/py-tree-sitter/issues/162
-          python-version: '3.11.x'
+          python-version: "3.12"
       - name: Install CLI
         run: |
           pip install codecov-cli
@@ -55,6 +54,7 @@ jobs:
       fail-fast: false
       matrix:
         include:
+          - python-version: "3.12"
           - python-version: "3.11"
           - python-version: "3.10"
           - python-version: "3.9"
@@ -65,14 +65,14 @@ jobs:
         submodules: true
         fetch-depth: 2
     - name: Set up Python ${{matrix.python-version}}
-      uses: actions/setup-python@v3
+      uses: actions/setup-python@v5
       with:
         python-version: "${{matrix.python-version}}"
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
         pip install -r requirements.txt
-        python setup.py develop
+        python -m pip install -e .
         pip install -r tests/requirements.txt
     - name: Test with pytest
       run: |
@@ -92,10 +92,9 @@ jobs:
         with:
           submodules: true
           fetch-depth: 2
-      - uses: actions/setup-python@v3
+      - uses: actions/setup-python@v5
         with:
-          # Because of https://github.com/tree-sitter/py-tree-sitter/issues/162
-          python-version: '3.11.x'
+          python-version: "3.12"
       - name: Install CLI
         run: |
           pip install codecov-cli
@@ -116,10 +115,9 @@ jobs:
         with:
           submodules: true
           fetch-depth: 0
-      - uses: actions/setup-python@v3
+      - uses: actions/setup-python@v5
         with:
-          # Because of https://github.com/tree-sitter/py-tree-sitter/issues/162
-          python-version: '3.11.x'
+          python-version: "3.12"
       - name: Install CLI
         run: |
           pip install -r requirements.txt -r tests/requirements.txt
@@ -141,6 +139,7 @@ jobs:
       fail-fast: false
       matrix:
         include:
+          - python-version: "3.12"
           - python-version: "3.11"
           - python-version: "3.10"
           - python-version: "3.9"
@@ -151,14 +150,14 @@ jobs:
         submodules: true
         fetch-depth: 2
     - name: Set up Python ${{matrix.python-version}}
-      uses: actions/setup-python@v3
+      uses: actions/setup-python@v5
       with:
         python-version: "${{matrix.python-version}}"
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
         pip install -r requirements.txt
-        python setup.py develop
+        python -m pip install -e .
         pip install -r tests/requirements.txt
     - name: Test with pytest
       run: |

--- a/codecov_cli/helpers/ci_adapters/codebuild.py
+++ b/codecov_cli/helpers/ci_adapters/codebuild.py
@@ -12,7 +12,7 @@ class AWSCodeBuildCIAdapter(CIAdapterBase):
     def _get_branch(self):
         branch = os.getenv("CODEBUILD_WEBHOOK_HEAD_REF")
         if branch:
-            return re.sub("^refs\/heads\/", "", branch)
+            return re.sub(r"^refs\/heads\/", "", branch)
         return None
 
     def _get_build_code(self):
@@ -27,10 +27,10 @@ class AWSCodeBuildCIAdapter(CIAdapterBase):
     def _get_slug(self):
         slug = os.getenv("CODEBUILD_SOURCE_REPO_URL")
         if slug:
-            slug = re.sub("^.*github.com\/", "", slug)
-            slug = re.sub("^.*gitlab.com\/", "", slug)
-            slug = re.sub("^.*bitbucket.com\/", "", slug)
-            return re.sub("\.git$", "", slug)
+            slug = re.sub(r"^.*github.com\/", "", slug)
+            slug = re.sub(r"^.*gitlab.com\/", "", slug)
+            slug = re.sub(r"^.*bitbucket.com\/", "", slug)
+            return re.sub(r"\.git$", "", slug)
         return None
 
     def _get_service(self):
@@ -39,7 +39,7 @@ class AWSCodeBuildCIAdapter(CIAdapterBase):
     def _get_pull_request_number(self):
         pr = os.getenv("CODEBUILD_SOURCE_VERSION")
         if pr and pr.startswith("pr/"):
-            return re.sub("^pr\/", "", pr)
+            return re.sub(r"^pr\/", "", pr)
         return None
 
     def _get_job_code(self):


### PR DESCRIPTION
This adds basic support for python 3.12:

- An unescaped `\` now [raises a SyntaxWarning](https://docs.python.org/3/whatsnew/3.12.html#other-language-changes)
- Since 3.12 [removed setuptools](https://docs.python.org/3/whatsnew/3.12.html#ensurepip), `python setup.py` will fail to import setuptools. Note that directly executing setup.py has been [unofficially deprecated/discouraged](https://packaging.python.org/en/latest/discussions/setup-py-deprecated/) for a while, so I've updated to use `pip` instead (there are other places as well but those might take more work)
