### PR TITLE
🐛 Use config-set token as CLI default fallback

### DIFF
--- a/codecov_cli/main.py
+++ b/codecov_cli/main.py
@@ -58,6 +58,8 @@ def cli(
     ctx.obj["codecov_yaml"] = load_cli_config(codecov_yml_path)
     if ctx.obj["codecov_yaml"] is None:
         logger.debug("No codecov_yaml found")
+    elif (token := ctx.obj["codecov_yaml"].get("codecov", {}).get("token")) is not None:
+        ctx.default_map = {ctx.invoked_subcommand: {"token": token}}
     ctx.obj["enterprise_url"] = enterprise_url
 
 

--- a/tests/commands/test_upload_token_discovery.py
+++ b/tests/commands/test_upload_token_discovery.py
@@ -1,0 +1,46 @@
+"""Tests ensuring that an env-provided token can be found."""
+
+from pathlib import Path
+from textwrap import dedent as _dedent_text_block
+
+from click.testing import CliRunner
+from pytest import MonkeyPatch
+from pytest_mock import MockerFixture
+
+from codecov_cli.commands import upload
+from codecov_cli.main import cli
+
+
+def test_no_cli_token_config_fallback(
+    mocker: MockerFixture,
+    monkeypatch: MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Test that a config-stored token is used with no CLI argument."""
+    # NOTE: The pytest's `caplog` fixture is not used in this test as it
+    # NOTE: doesn't play well with Click's testing CLI runner, and does
+    # NOTE: not capture any log entries for mysterious reasons.
+    #
+    # Refs:
+    # * https://github.com/pallets/click/issues/2573#issuecomment-1649773563
+    # * https://github.com/pallets/click/issues/1763#issuecomment-767687608
+    (tmp_path / ".codecov.yml").write_text(
+        _dedent_text_block(
+            """
+            ---
+
+            codecov:
+              token: sentinel-value
+
+            ...
+            """
+        )
+    )
+    monkeypatch.chdir(tmp_path)
+
+    mocker.patch.object(upload, "do_upload_logic")
+    do_upload_cmd_spy = mocker.spy(upload, "do_upload_logic")
+
+    CliRunner().invoke(cli, ["do-upload", "--commit-sha=deadbeef"], obj={})
+
+    assert do_upload_cmd_spy.call_args[-1]["token"] == "sentinel-value"


### PR DESCRIPTION
Just like in the old days... Before this patch, the v4-related rewrite of the Codecov uploader CLI lost the ability to use the token set in the config file [[1]]. This change fixes the regression recovering the original behavior.

The bug has been discovered during the re-configuration of ``codecov/codecov-action`` in ``pytest-dev/pytest``. We use the clear-text token to improve stability of uploads in PRs from forks so it makes sense to keep it in the config rather than in the GitHub Actions CI/CD definition file.

[1]: https://docs.codecov.com/docs/codecovyml-reference#codecovtoken