### PR TITLE
CI: redo building wheels for pypi

### DIFF
--- a/.github/workflows/build_for_pypi.yml
+++ b/.github/workflows/build_for_pypi.yml
@@ -10,32 +10,77 @@ on:
 
 jobs:
   build_for_pypi:
+    name: Build wheels on ${{ matrix.os }} ${{ matrix.cibw_arch }}
+    runs-on: ${{ matrix.os }}
+    permissions:
+      contents: read  # This is required for actions/checkout
+    strategy:
+      matrix:
+        include:
+          - { os: windows-latest, cibw_arch: AMD64 }
+          - { os: ubuntu-latest,  cibw_arch: x86_64 }
+          - { os: ubuntu-latest,  cibw_arch: aarch64, qemu_arch: arm64 }
+          - { os: macos-latest,   cibw_arch: arm64 }
+          - { os: macos-latest,   cibw_arch: x86_64 }
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: true
+
+      - name: Set up Python 3.11
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.11"
+
+      - name: Set up QEMU
+        if: matrix.qemu_arch != ''
+        uses: docker/setup-qemu-action@v3
+        with:
+          platforms: matrix.qemu_arch
+
+      - name: Build wheels
+        uses: pypa/cibuildwheel@v2.20.0
+        env:
+          CIBW_ARCHS: ${{matrix.cibw_arch}}
+          # 20 Aug 2024: Building wheels for PyPy fails, so skip
+          CIBW_SKIP: pp*
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: cibw-wheels-${{ matrix.os }}-${{ strategy.job-index }}
+          path: ./wheelhouse/*.whl
+
+  build_sdist:
+    name: Build source distribution
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read  # This is required for actions/checkout
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Build sdist
+        run: pipx run build --sdist
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: cibw-sdist
+          path: dist/*.tar.gz
+
+  upload_pypi:
+    needs: [build_for_pypi, build_sdist]
     runs-on: ubuntu-latest
     permissions:
       id-token: write # This is required for requesting the JWT
       contents: read  # This is required for actions/checkout
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/download-artifact@v4
         with:
-          submodules: true
-      - name: Set up Python 3.11
-        uses: actions/setup-python@v4
-        with:
-          python-version: "3.11"
-      - name: Install dependencies
-        run: |
-          pip install -r requirements.txt
-          python setup.py build
-          python setup.py develop
-      - name: Build distributions for different platforms
-        run: |
-          pip install wheel
-          python setup.py sdist bdist_wheel --plat-name=manylinux2014_x86_64
-          python setup.py bdist_wheel --plat-name=macosx-12.6-x86_64
-          python setup.py bdist_wheel --plat-name=win_amd64
-      - name: Publish package to PyPi
+          # unpacks all CIBW artifacts into dist/
+          pattern: cibw-*
+          path: dist
+          merge-multiple: true
+
+      - name: Publish package to PyPI
         if: inputs.publish == true
         uses: pypa/gh-action-pypi-publish@release/v1
-
-
-


### PR DESCRIPTION
the python packaging authority has a tool called [`cibuildwheel`](https://github.com/pypa/cibuildwheel) to make building wheels across platforms, architectures, and python versions way way easier. this PR swaps out our setup to use it

it will also build a wider/better array of wheels:
- using macOS 13 (x64) and 14 (arm64) instead of just 12 (x64)
- adding manylinux aarch64, no longer just x64
- adding musllinux, both x64 and aarch64