### PR TITLE
chore: automatically acquire branch name for CircleCI

### DIFF
--- a/codecov_cli/helpers/ci_adapters/local.py
+++ b/codecov_cli/helpers/ci_adapters/local.py
@@ -12,7 +12,7 @@ class LocalAdapter(CIAdapterBase):
         return s.returncode == SUCCESS
 
     def _get_branch(self):
-        return os.getenv("GIT_BRANCH") or os.getenv("BRANCH_NAME")
+        return os.getenv("GIT_BRANCH") or os.getenv("CIRCLE_BRANCH") or os.getenv("BRANCH_NAME")
 
     def _get_build_code(self):
         return None


### PR DESCRIPTION
https://circleci.com/docs/variables/

Since Codecov provides a CircleCI orb, let's make it easier to acquire the branch name without additional config.