### PR TITLE
Aggregate the test results files in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,12 +76,18 @@ jobs:
         pip install -r tests/requirements.txt
     - name: Test with pytest
       run: |
-        pytest --cov --junitxml=junit.xml
+        pytest --cov --junitxml=${{matrix.python-version}}junit.xml
     - name: Dogfooding codecov-cli
       if: ${{ !github.event.pull_request.head.repo.fork && github.repository_owner == 'codecov' }}
       run: |
         codecovcli -v do-upload --fail-on-error -t ${{ secrets.CODECOV_TOKEN }} --plugin pycoverage --flag python${{matrix.python-version}}
         codecovcli do-upload --report-type test_results --fail-on-error -t ${{ secrets.CODECOV_TOKEN }} --plugin pycoverage --flag python${{matrix.python-version}}
+    - name: Upload artifacts for test-results-processing
+      if: ${{ always() }}
+      uses: actions/upload-artifact@v4
+      with:
+        name: ${{matrix.python-version}}junit.xml
+        path: ${{matrix.python-version}}junit.xml
 
   static-analysis:
     runs-on: ubuntu-latest
@@ -131,38 +137,31 @@ jobs:
         run: |
           codecovcli --codecov-yml-path=codecov.yml do-upload --plugin pycoverage --plugin compress-pycoverage --fail-on-error -t ${{ secrets.CODECOV_TOKEN }} --flag smart-labels
 
-  test-process-test-results-cmd:
+  process-test-results:
+    if: ${{ always() }}
+    needs: build-test-upload
     runs-on: ubuntu-latest
-    permissions:
-      pull-requests: write
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - python-version: "3.12"
-          - python-version: "3.11"
-          - python-version: "3.10"
-          - python-version: "3.9"
-          - python-version: "3.8"
     steps:
-    - uses: actions/checkout@v4
-      with:
-        submodules: true
-        fetch-depth: 2
-    - name: Set up Python ${{matrix.python-version}}
-      uses: actions/setup-python@v5
-      with:
-        python-version: "${{matrix.python-version}}"
-    - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip
-        pip install -r requirements.txt
-        python -m pip install -e .
-        pip install -r tests/requirements.txt
-    - name: Test with pytest
-      run: |
-        pytest --cov --junitxml=junit.xml
-    - name: Dogfooding codecov-cli
-      if: ${{ !cancelled() }}
-      run: |
-        codecovcli process-test-results --provider-token ${{ secrets.GITHUB_TOKEN }}
+      - uses: actions/checkout@v4
+        with:
+          submodules: true
+          fetch-depth: 2
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Install dependencies for Dogfooding
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+          python -m pip install -e .
+          pip install -r tests/requirements.txt
+      - name: Download all test results
+        uses: actions/download-artifact@v4
+        with:
+          pattern: "*junit.xml"
+          path: "test_results"
+          merge-multiple: true
+      - name: Dogfooding codecov-cli
+        if: ${{ !cancelled() }}
+        run: |
+          codecovcli process-test-results --provider-token ${{ secrets.GITHUB_TOKEN }} --dir test_results


### PR DESCRIPTION
Update the CI to aggregate results all into one comment. This will be useful for extracting into its own action in the future.

Basically, changes needed to ensure one comment:
- test junit.xml files are exported to an artifact of some `${UNIQUE_IDENTIFIER}junit.xml`
- an "aggregation" job that puts all the `*junit.xml` files into a directly
- calling process_test_results with the dir with all the junit files

I've added a breaking test for testing purposes. Once I get an approval, I'll remove it.