### PR TITLE
Ensure that we run offline test analytics on PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -162,6 +162,6 @@ jobs:
           path: "test_results"
           merge-multiple: true
       - name: Dogfooding codecov-cli
-        if: ${{ !cancelled() && github.ref }}
+        if: ${{ !cancelled() && github.ref && contains(github.ref, 'pull') }}
         run: |
           codecovcli process-test-results --provider-token ${{ secrets.GITHUB_TOKEN }} --dir test_results


### PR DESCRIPTION
The ref can also reference a branch when it's merged. Ensure that we're only running this for a PR.