### PR TITLE
Better formatting of options for the `empty-upload` command

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,14 +240,14 @@ are ignored by codecov (including README and configuration files)
 
 `Usage: codecovcli empty-upload [OPTIONS]`
 
-Options:
-  -C, --sha, --commit-sha TEXT    Commit SHA (with 40 chars)  [required]
-  -Z, --fail-on-error             Exit with non-zero code in case of error
-  --git-service [github|gitlab|bitbucket|github_enterprise|gitlab_enterprise|bitbucket_server]
-  -t, --token TEXT                Codecov upload token
-  -r, --slug TEXT                 owner/repo slug used instead of the private
-                                  repo token in Self-hosted
-  -h, --help                      Show this message and exit.
+| Options | Description | usage
+| :---:  |  :---:  |  :---:  |
+ | -C, --sha, --commit-sha TEXT    |Commit SHA (with 40 chars)  | Required
+ |  -t, --token TEXT                |Codecov upload token |Required
+|  -r, --slug TEXT               |  owner/repo slug used instead of the private repo token in Self-hosted | Optional
+|  -Z, --fail-on-error            | Exit with non-zero code in case of error|Optional
+|  --git-service| Options: github, gitlab, bitbucket, github_enterprise, gitlab_enterprise, bitbucket_server | Optional
+| -h, --help                   |   Show this message and exit.|Optional
 
 # How to Use Local Upload
 


### PR DESCRIPTION
Better formatting of options for the `empty-upload` command