### PR TITLE
fix: make default search case insensitive

### DIFF
--- a/codecov_cli/helpers/folder_searcher.py
+++ b/codecov_cli/helpers/folder_searcher.py
@@ -85,7 +85,9 @@ def search_files(
                     yield file_path
 
 
-def globs_to_regex(patterns: List[str]) -> Optional[Pattern]:
+def globs_to_regex(
+    patterns: List[str], case_sensitive: bool = True
+) -> Optional[Pattern]:
     """
     Converts a list of glob patterns to a combined ORed regex
 
@@ -100,4 +102,8 @@ def globs_to_regex(patterns: List[str]) -> Optional[Pattern]:
         return None
 
     regex_str = ["(" + translate(pattern) + ")" for pattern in patterns]
-    return re.compile("|".join(regex_str))
+    # return re.compile("|".join(regex_str))
+    if case_sensitive:
+        return re.compile("|".join(regex_str))
+    else:
+        return re.compile("|".join(regex_str), re.IGNORECASE)

--- a/codecov_cli/helpers/folder_searcher.py
+++ b/codecov_cli/helpers/folder_searcher.py
@@ -102,7 +102,6 @@ def globs_to_regex(
         return None
 
     regex_str = ["(" + translate(pattern) + ")" for pattern in patterns]
-    # return re.compile("|".join(regex_str))
     if case_sensitive:
         return re.compile("|".join(regex_str))
     else:

--- a/codecov_cli/services/upload/file_finder.py
+++ b/codecov_cli/services/upload/file_finder.py
@@ -128,7 +128,7 @@ coverage_files_excluded_patterns = [
     "inputFiles.lst",
     "phpunit-code-coverage.xml",
     "phpunit-coverage.xml",
-    "remapInstanbul.coverage*.json",
+    "remapIstanbul.coverage*.json",
     "scoverage.measurements.*",
     "test_*_coverage.txt",
     "test-result-*-codecoverage.json",

--- a/codecov_cli/services/upload/file_finder.py
+++ b/codecov_cli/services/upload/file_finder.py
@@ -209,7 +209,9 @@ class FileFinder(object):
         if self.explicitly_listed_files:
             user_files_paths = self.get_user_specified_files(regex_patterns_to_exclude)
         if not self.disable_search:
-            regex_patterns_to_include = globs_to_regex(files_patterns)
+            regex_patterns_to_include = globs_to_regex(
+                files_patterns, case_sensitive=False
+            )
             assert regex_patterns_to_include  # this is never `None`
             files_paths = search_files(
                 self.search_root,

--- a/tests/services/upload/test_coverage_file_finder.py
+++ b/tests/services/upload/test_coverage_file_finder.py
@@ -101,7 +101,12 @@ class TestCoverageFileFinder(object):
         (tmp_path / "sub" / "subsub").mkdir()
         (tmp_path / "node_modules").mkdir()
 
-        should_find = ["junit.xml", "abc.junit.xml", "sub/junit.xml"]
+        should_find = [
+            "junit.xml",
+            "abc.junit.xml",
+            "sub/junit.xml",
+            "sub/TEST-something.xml",
+        ]
 
         should_ignore = [
             "abc.codecov.exe",
@@ -330,6 +335,7 @@ class TestCoverageFileFinderUserInput:
             project_root / "coverage.xml",
             project_root / "subdirectory" / "test_coverage.xml",
             project_root / ".tox" / "another_file.abc",
+            project_root / ".tox" / "ANOTHER_FILE.abc",
         ]
         (project_root / "subdirectory").mkdir()
         (project_root / ".tox").mkdir()


### PR DESCRIPTION
when looking for files in the default patterns search, it's better to
be flexible and not care about case sensitive matching. For example,
certain frameworks output their test results with the word "test" in
all upper case and we shouldn't need to specify both "test" and "TEST"
to match those files.
