### PR TITLE
add macOS ARM64 wheel build

### DIFF
--- a/.github/workflows/build_for_pypi.yml
+++ b/.github/workflows/build_for_pypi.yml
@@ -32,6 +32,7 @@ jobs:
           pip install wheel
           python setup.py sdist bdist_wheel --plat-name=manylinux2014_x86_64
           python setup.py bdist_wheel --plat-name=macosx-12.6-x86_64
+          python setup.py bdist_wheel --plat-name=macosx-12.6-arm64
           python setup.py bdist_wheel --plat-name=win_amd64
       - name: Publish package to PyPi
         if: inputs.publish == true


### PR DESCRIPTION
Fixes: https://github.com/codecov/codecov-cli/issues/409

Adds macOS ARM64 wheel build while maintaining x86_64 wheel support. This helps address installation issues on Apple Silicon Macs where users currently need to build from source, which can be problematic due to C++ compiler requirements (see #409).

## Changes
- Added `bdist_wheel` command with `macosx-12.6-arm64` platform tag
- Maintained existing `macosx-12.6-x86_64` wheel for Intel Mac support

## Why
Currently, users on Apple Silicon Macs may need to build from source, which requires specific Xcode Command Line Tools versions and C++ compiler configurations. By providing pre-built wheels for both architectures, we can:
1. Reduce installation friction for users on both Intel and Apple Silicon Macs
2. Avoid compiler-related issues described in #409
3. Ensure proper compilation of C++ extensions for each architecture

## Testing Help Needed
@thomasrockhu-codecov Could you help test this change? We need to verify:
- [ ] ARM64 wheel builds successfully
- [ ] Installation works on both M1/M2 and Intel Macs