### PR TITLE
feat: add telemetry

### DIFF
--- a/.github/workflows/build_assets.yml
+++ b/.github/workflows/build_assets.yml
@@ -19,7 +19,7 @@ jobs:
           - os: macos-13
             TARGET: macos
             CMD_REQS: >
-              mkdir -p pip-packages && cd pip-packages && pip wheel --no-cache-dir --no-binary tree_sitter,ijson,charset_normalizer,PyYAML .. && cd .. &&
+              mkdir -p pip-packages && cd pip-packages && pip download wrapt --platform=universal2 --only-binary=:all: && pip install $(ls | grep wrapt)  && pip wheel --no-cache-dir --no-binary tree_sitter,ijson,charset_normalizer,PyYAML .. && cd .. &&
               pip install --no-deps --no-index --find-links=pip-packages pip-packages/*
             CMD_BUILD: >
               STATICCODECOV_LIB_PATH=$(find build/ -maxdepth 1 -type d -name 'lib.*' -print -quit | xargs -I {} sh -c "find {} -type f -name 'staticcodecov*' -print -quit | sed 's|^./||'") &&

--- a/.github/workflows/build_assets.yml
+++ b/.github/workflows/build_assets.yml
@@ -19,7 +19,8 @@ jobs:
           - os: macos-13
             TARGET: macos
             CMD_REQS: >
-              mkdir -p pip-packages && cd pip-packages && pip download wrapt --platform=universal2 --only-binary=:all: && pip install $(ls | grep wrapt)  && pip wheel --no-cache-dir --no-binary tree_sitter,ijson,charset_normalizer,PyYAML .. && cd .. &&
+              mkdir -p pip-packages && cd pip-packages && pip wheel --no-cache-dir --no-binary tree_sitter,ijson,charset_normalizer,PyYAML .. &&
+              rm $(ls | grep wrapt) && pip download wrapt --platform=universal2 --only-binary=:all: && pip install $(ls | grep wrapt) --force-reinstall && cd .. &&
               pip install --no-deps --no-index --find-links=pip-packages pip-packages/*
             CMD_BUILD: >
               STATICCODECOV_LIB_PATH=$(find build/ -maxdepth 1 -type d -name 'lib.*' -print -quit | xargs -I {} sh -c "find {} -type f -name 'staticcodecov*' -print -quit | sed 's|^./||'") &&

--- a/.github/workflows/build_assets.yml
+++ b/.github/workflows/build_assets.yml
@@ -94,7 +94,7 @@ jobs:
           - distro: "python:3.11-bullseye"
             arch: arm64
             distro_name: linux
-            
+
     steps:
     - uses: actions/checkout@v4
       with:
@@ -127,6 +127,3 @@ jobs:
         asset_name: codecovcli_${{ matrix.distro_name }}_${{ matrix.arch }}
         tag: ${{ github.ref }}
         overwrite: true
-    
-
-

--- a/.github/workflows/build_assets.yml
+++ b/.github/workflows/build_assets.yml
@@ -16,7 +16,7 @@ jobs:
       fail-fast: true
       matrix:
         include:
-          - os: macos-latest
+          - os: macos-13
             TARGET: macos
             CMD_REQS: >
               mkdir -p pip-packages && cd pip-packages && pip wheel --no-cache-dir --no-binary tree_sitter,ijson,charset_normalizer,PyYAML .. && cd .. &&

--- a/.github/workflows/build_assets.yml
+++ b/.github/workflows/build_assets.yml
@@ -23,10 +23,8 @@ jobs:
               pip install --no-deps --no-index --find-links=pip-packages pip-packages/*
             CMD_BUILD: >
               STATICCODECOV_LIB_PATH=$(find build/ -maxdepth 1 -type d -name 'lib.*' -print -quit | xargs -I {} sh -c "find {} -type f -name 'staticcodecov*' -print -quit | sed 's|^./||'") &&
-              pyinstaller --add-binary ${STATICCODECOV_LIB_PATH}:. --copy-metadata codecov-cli --hidden-import staticcodecov_languages --target-arch arm64 -F codecov_cli/main.py &&
-              mv dist/main dist/codecovcli_macos_arm64 &&
-              pyinstaller --add-binary ${STATICCODECOV_LIB_PATH}:. --copy-metadata codecov-cli --hidden-import staticcodecov_languages --target-arch x86_64 -F codecov_cli/main.py &&
-              mv dist/main dist/codecovcli_macos_x86_64 &&
+              pyinstaller --add-binary ${STATICCODECOV_LIB_PATH}:. --copy-metadata codecov-cli --hidden-import staticcodecov_languages --target-arch universal2 -F codecov_cli/main.py &&
+              mv dist/main dist/codecovcli_macos &&
               lipo -archs dist/codecovcli_macos | grep 'x86_64 arm64' &&
               cd dist && ls -al && cd ..
             OUT_FILE_NAME: codecovcli_macos

--- a/.github/workflows/build_assets.yml
+++ b/.github/workflows/build_assets.yml
@@ -19,9 +19,9 @@ jobs:
         include:
           - os: macos-latest
             TARGET: macos
+            # currently, wrapt pulls the arm64 version instead of the universal one, so the below is a hack
             CMD_REQS: >
               mkdir -p pip-packages && cd pip-packages && pip wheel --no-cache-dir --no-binary tree_sitter,ijson,charset_normalizer,PyYAML .. &&
-              # currently, wrapt pulls the arm64 version instead of the universal one, so the below is a hack
               rm $(ls | grep wrapt) && pip download wrapt --platform=universal2 --only-binary=:all: && pip install $(ls | grep wrapt) --force-reinstall && cd .. &&
               pip install --no-deps --no-index --find-links=pip-packages pip-packages/*
             CMD_BUILD: >

--- a/.github/workflows/build_assets.yml
+++ b/.github/workflows/build_assets.yml
@@ -23,9 +23,12 @@ jobs:
               pip install --no-deps --no-index --find-links=pip-packages pip-packages/*
             CMD_BUILD: >
               STATICCODECOV_LIB_PATH=$(find build/ -maxdepth 1 -type d -name 'lib.*' -print -quit | xargs -I {} sh -c "find {} -type f -name 'staticcodecov*' -print -quit | sed 's|^./||'") &&
-              pyinstaller --add-binary ${STATICCODECOV_LIB_PATH}:. --copy-metadata codecov-cli --hidden-import staticcodecov_languages --target-arch universal2 -F codecov_cli/main.py &&
-              mv dist/main dist/codecovcli_macos &&
-              lipo -archs dist/codecovcli_macos | grep 'x86_64 arm64'
+              pyinstaller --add-binary ${STATICCODECOV_LIB_PATH}:. --copy-metadata codecov-cli --hidden-import staticcodecov_languages --target-arch arm64 -F codecov_cli/main.py &&
+              mv dist/main dist/codecovcli_macos_arm64 &&
+              pyinstaller --add-binary ${STATICCODECOV_LIB_PATH}:. --copy-metadata codecov-cli --hidden-import staticcodecov_languages --target-arch x86_64 -F codecov_cli/main.py &&
+              mv dist/main dist/codecovcli_macos_x86_64 &&
+              lipo -archs dist/codecovcli_macos | grep 'x86_64 arm64' &&
+              cd dist && ls -al && cd ..
             OUT_FILE_NAME: codecovcli_macos
             ASSET_MIME: application/octet-stream
           - os: ubuntu-20.04

--- a/.github/workflows/build_assets.yml
+++ b/.github/workflows/build_assets.yml
@@ -1,3 +1,4 @@
+---
 name: Build Compiled Assets
 
 on:
@@ -16,18 +17,18 @@ jobs:
       fail-fast: true
       matrix:
         include:
-          - os: macos-13
+          - os: macos-latest
             TARGET: macos
             CMD_REQS: >
               mkdir -p pip-packages && cd pip-packages && pip wheel --no-cache-dir --no-binary tree_sitter,ijson,charset_normalizer,PyYAML .. &&
+              # currently, wrapt pulls the arm64 version instead of the universal one, so the below is a hack
               rm $(ls | grep wrapt) && pip download wrapt --platform=universal2 --only-binary=:all: && pip install $(ls | grep wrapt) --force-reinstall && cd .. &&
               pip install --no-deps --no-index --find-links=pip-packages pip-packages/*
             CMD_BUILD: >
               STATICCODECOV_LIB_PATH=$(find build/ -maxdepth 1 -type d -name 'lib.*' -print -quit | xargs -I {} sh -c "find {} -type f -name 'staticcodecov*' -print -quit | sed 's|^./||'") &&
               pyinstaller --add-binary ${STATICCODECOV_LIB_PATH}:. --copy-metadata codecov-cli --hidden-import staticcodecov_languages --target-arch universal2 -F codecov_cli/main.py &&
               mv dist/main dist/codecovcli_macos &&
-              lipo -archs dist/codecovcli_macos | grep 'x86_64 arm64' &&
-              cd dist && ls -al && cd ..
+              lipo -archs dist/codecovcli_macos | grep 'x86_64 arm64'
             OUT_FILE_NAME: codecovcli_macos
             ASSET_MIME: application/octet-stream
           - os: ubuntu-20.04

--- a/.github/workflows/build_for_pypi.yml
+++ b/.github/workflows/build_for_pypi.yml
@@ -31,7 +31,7 @@ jobs:
         run: |
           pip install wheel
           python setup.py sdist bdist_wheel --plat-name=manylinux2014_x86_64
-          python setup.py bdist_wheel --plat-name=macosx-12.6-x86_64
+          python setup.py bdist_wheel --plat-name=macosx-12.6-universal2
           python setup.py bdist_wheel --plat-name=win_amd64
       - name: Publish package to PyPi
         if: inputs.publish == true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,11 +48,11 @@ jobs:
       fail-fast: false
       matrix:
         include:
+          - python-version: "3.13"
           - python-version: "3.12"
           - python-version: "3.11"
           - python-version: "3.10"
           - python-version: "3.9"
-          - python-version: "3.8"
     steps:
     - uses: actions/checkout@v4
       with:

--- a/codecov_cli/helpers/ci_adapters/azure_pipelines.py
+++ b/codecov_cli/helpers/ci_adapters/azure_pipelines.py
@@ -16,7 +16,7 @@ class AzurePipelinesCIAdapter(CIAdapterBase):
 
     def _get_build_url(self):
         if os.getenv("SYSTEM_TEAMPROJECT") and os.getenv("BUILD_BUILDID"):
-            return f'{os.getenv("SYSTEM_TEAMFOUNDATIONCOLLECTIONURI")}{os.getenv("SYSTEM_TEAMPROJECT")}/_build/results?buildId={os.getenv("BUILD_BUILDID")}'
+            return f"{os.getenv('SYSTEM_TEAMFOUNDATIONCOLLECTIONURI')}{os.getenv('SYSTEM_TEAMPROJECT')}/_build/results?buildId={os.getenv('BUILD_BUILDID')}"
 
     def _get_build_code(self):
         return os.getenv("BUILD_BUILDNUMBER")

--- a/codecov_cli/main.py
+++ b/codecov_cli/main.py
@@ -5,6 +5,7 @@ import typing
 import click
 
 from codecov_cli import __version__
+from codecov_cli.opentelemetry import init_telem
 from codecov_cli.commands.base_picking import pr_base_picking
 from codecov_cli.commands.commit import create_commit
 from codecov_cli.commands.create_report_result import create_report_results
@@ -43,6 +44,9 @@ logger = logging.getLogger("codecovcli")
     "--enterprise-url", "--url", "-u", help="Change the upload host (Enterprise use)"
 )
 @click.option("-v", "--verbose", "verbose", help="Use verbose logging", is_flag=True)
+@click.option(
+    "--disable-telem", help="Disable sending telemetry data to Codecov", is_flag=True
+)
 @click.pass_context
 @click.version_option(__version__, prog_name="codecovcli")
 def cli(
@@ -51,6 +55,7 @@ def cli(
     codecov_yml_path: pathlib.Path,
     enterprise_url: str,
     verbose: bool = False,
+    disable_telem: bool = False,
 ):
     ctx.obj["cli_args"] = ctx.params
     ctx.obj["cli_args"]["version"] = f"cli-{__version__}"
@@ -64,6 +69,9 @@ def cli(
     elif (token := ctx.obj["codecov_yaml"].get("codecov", {}).get("token")) is not None:
         ctx.default_map = {ctx.invoked_subcommand: {"token": token}}
     ctx.obj["enterprise_url"] = enterprise_url
+
+    if not disable_telem:
+        init_telem(__version__, enterprise_url)
 
 
 cli.add_command(do_upload)

--- a/codecov_cli/opentelemetry.py
+++ b/codecov_cli/opentelemetry.py
@@ -1,0 +1,32 @@
+import os
+import time
+
+from opentelemetry import trace
+from opentelemetry.propagate import set_global_textmap
+from opentelemetry.sdk.trace import TracerProvider
+import sentry_sdk
+from sentry_sdk.integrations.opentelemetry import SentrySpanProcessor, SentryPropagator
+
+
+def init_telem(version, url):
+    if url:  # dont run on dedicated cloud
+        return
+
+    if os.getenv("IS_CI", False):
+        return
+
+    sentry_sdk.init(
+        dsn="https://0bea75c61745c221a6ef1ac1709b1f4d@o26192.ingest.us.sentry.io/4508615876083713",
+        enable_tracing=True,
+        release=f"cli@{version}",
+        instrumenter="otel",
+    )
+
+    provider = TracerProvider()
+    provider.add_span_processor(SentrySpanProcessor())
+    trace.set_tracer_provider(provider)
+    set_global_textmap(SentryPropagator())
+
+
+def close_telem():
+    sentry_sdk.flush()

--- a/codecov_cli/plugins/__init__.py
+++ b/codecov_cli/plugins/__init__.py
@@ -58,7 +58,7 @@ def _load_plugin_from_yaml(plugin_dict: typing.Dict):
 
     except TypeError:
         click.secho(
-            f"Unable to instantiate {class_obj} with provided parameters { plugin_dict.get('params', '') }",
+            f"Unable to instantiate {class_obj} with provided parameters {plugin_dict.get('params', '')}",
             err=True,
         )
         return NoopPlugin()

--- a/codecov_cli/plugins/compress_pycoverage_contexts.py
+++ b/codecov_cli/plugins/compress_pycoverage_contexts.py
@@ -5,10 +5,12 @@ from decimal import Decimal
 from typing import Any, List
 
 import ijson
+from opentelemetry import trace
 
 from codecov_cli.plugins.types import PreparationPluginReturn
 
 logger = logging.getLogger("codecovcli")
+tracer = trace.get_tracer(__name__)
 
 
 class Encoder(json.JSONEncoder):
@@ -47,6 +49,7 @@ class CompressPycoverageContexts(object):
             str(self.file_to_compress).replace(".json", "") + ".codecov.json"
         )
 
+    @tracer.start_as_current_span("compress_pycoverage")
     def run_preparation(self, collector) -> PreparationPluginReturn:
         if not self.file_to_compress.exists():
             logger.warning(
@@ -120,7 +123,7 @@ class CompressPycoverageContexts(object):
         # Save the inverted index of labels table in the report
         # So when we are processing the result we have int -> label
         fd_out.write(
-            f'"labels_table": {json.dumps({ value: key for key, value in labels_table.items() })}'
+            f'"labels_table": {json.dumps({value: key for key, value in labels_table.items()})}'
         )
 
     def _copy_file_details(self, file_name, file_details, fd_out) -> None:

--- a/codecov_cli/plugins/gcov.py
+++ b/codecov_cli/plugins/gcov.py
@@ -5,10 +5,13 @@ import shutil
 import subprocess
 import typing
 
+from opentelemetry import trace
+
 from codecov_cli.helpers.folder_searcher import globs_to_regex, search_files
 from codecov_cli.plugins.types import PreparationPluginReturn
 
 logger = logging.getLogger("codecovcli")
+tracer = trace.get_tracer(__name__)
 
 
 class GcovPlugin(object):
@@ -28,6 +31,7 @@ class GcovPlugin(object):
         self.patterns_to_include = patterns_to_include or []
         self.project_root = project_root or pathlib.Path(os.getcwd())
 
+    @tracer.start_as_current_span("gcov")
     def run_preparation(self, collector) -> PreparationPluginReturn:
         logger.debug(
             f"Running {self.executable} plugin...",

--- a/codecov_cli/plugins/pycoverage.py
+++ b/codecov_cli/plugins/pycoverage.py
@@ -6,11 +6,14 @@ import subprocess
 import typing
 from glob import iglob
 
+from opentelemetry import trace
+
 from codecov_cli.helpers.folder_searcher import globs_to_regex, search_files
 from codecov_cli.plugins.types import PreparationPluginReturn
 
 coverage_files_regex = globs_to_regex([".coverage", ".coverage.*"])
 logger = logging.getLogger("codecovcli")
+tracer = trace.get_tracer(__name__)
 
 
 class PycoverageConfig(dict):
@@ -53,6 +56,7 @@ class Pycoverage(object):
     def __init__(self, config: dict):
         self.config = PycoverageConfig(config)
 
+    @tracer.start_as_current_span("pycoverage")
     def run_preparation(self, collector) -> PreparationPluginReturn:
         if shutil.which("coverage") is None:
             logger.warning("coverage.py is not installed or can't be found.")
@@ -68,7 +72,8 @@ class Pycoverage(object):
         if self.config.report_type == "json":
             return self._generate_JSON_report(coverage_dir)
         return PreparationPluginReturn(
-            success=False, messages=[f"report type {self.config.report_type} unknown"]
+            success=False,
+            messages=[f"report type {self.config.report_type} unknown"],
         )
 
     def _get_path_to_coverage(self) -> pathlib.Path:

--- a/codecov_cli/plugins/xcode.py
+++ b/codecov_cli/plugins/xcode.py
@@ -7,10 +7,13 @@ import subprocess
 import typing
 from fnmatch import translate
 
+from opentelemetry import trace
+
 from codecov_cli.helpers.folder_searcher import globs_to_regex, search_files
 from codecov_cli.plugins.types import PreparationPluginReturn
 
 logger = logging.getLogger("codecovcli")
+tracer = trace.get_tracer(__name__)
 
 
 class XcodePlugin(object):
@@ -28,6 +31,7 @@ class XcodePlugin(object):
         # if empty the plugin will build reports for every xcode project it finds
         self.app_name = app_name or ""
 
+    @tracer.start_as_current_span("xcode")
     def run_preparation(self, collector) -> PreparationPluginReturn:
         logger.debug("Running xcode plugin...")
 

--- a/codecov_cli/runners/pytest_standard_runner.py
+++ b/codecov_cli/runners/pytest_standard_runner.py
@@ -172,7 +172,7 @@ class PytestStandardRunner(LabelAnalysisRunnerInterface):
         logger.info(
             "Running tests. (run in verbose mode to get list of tests executed)"
         )
-        logger.info(f"  pytest options: \"{' '.join(default_options)}\"")
+        logger.info(f'  pytest options: "{" ".join(default_options)}"')
         logger.info(f"  executed tests: {len(tests_to_run)}")
         logger.debug(
             "List of tests executed",
@@ -180,5 +180,5 @@ class PytestStandardRunner(LabelAnalysisRunnerInterface):
         )
         output = self._execute_pytest(command_array, capture_output=False)
         logger.info(f"Finished running {len(tests_to_run)} tests successfully")
-        logger.info(f"  pytest options: \"{' '.join(default_options)}\"")
+        logger.info(f'  pytest options: "{" ".join(default_options)}"')
         logger.debug(output)

--- a/codecov_cli/services/upload/file_finder.py
+++ b/codecov_cli/services/upload/file_finder.py
@@ -3,10 +3,14 @@ import os
 from pathlib import Path
 from typing import Iterable, List, Optional, Pattern
 
+from opentelemetry import trace
+
 from codecov_cli.helpers.folder_searcher import globs_to_regex, search_files
 from codecov_cli.types import UploadCollectionResultFile
 
 logger = logging.getLogger("codecovcli")
+tracer = trace.get_tracer(__name__)
+
 
 coverage_files_patterns = [
     "*.clover",
@@ -197,6 +201,7 @@ class FileFinder(object):
         self.disable_search = disable_search
         self.report_type = report_type
 
+    @tracer.start_as_current_span("find_files")
     def find_files(self) -> List[UploadCollectionResultFile]:
         if self.report_type == "coverage":
             files_excluded_patterns = coverage_files_excluded_patterns

--- a/codecov_cli/services/upload/legacy_upload_sender.py
+++ b/codecov_cli/services/upload/legacy_upload_sender.py
@@ -2,12 +2,15 @@ import logging
 import typing
 from dataclasses import dataclass
 
+from opentelemetry import trace
+
 from codecov_cli import __version__ as codecov_cli_version
 from codecov_cli.helpers.config import LEGACY_CODECOV_API_URL
 from codecov_cli.helpers.request import send_post_request, send_put_request
 from codecov_cli.types import UploadCollectionResult, UploadCollectionResultFile
 
 logger = logging.getLogger("codecovcli")
+tracer = trace.get_tracer(__name__)
 
 
 @dataclass
@@ -32,6 +35,7 @@ class UploadSendingResult(object):
 
 
 class LegacyUploadSender(object):
+    @tracer.start_as_current_span("upload_legacy")
     def send_upload_data(
         self,
         upload_data: UploadCollectionResult,

--- a/codecov_cli/services/upload/upload_collector.py
+++ b/codecov_cli/services/upload/upload_collector.py
@@ -7,6 +7,7 @@ from collections import namedtuple
 from fnmatch import fnmatch
 
 import click
+from opentelemetry import trace
 
 from codecov_cli.services.upload.file_finder import FileFinder
 from codecov_cli.services.upload.network_finder import NetworkFinder
@@ -17,6 +18,7 @@ from codecov_cli.types import (
 )
 
 logger = logging.getLogger("codecovcli")
+tracer = trace.get_tracer(__name__)
 
 fix_patterns_to_apply = namedtuple(
     "fix_patterns_to_apply", ["without_reason", "with_reason", "eof"]
@@ -148,13 +150,15 @@ class UploadCollector(object):
             path, fixed_lines_without_reason, fixed_lines_with_reason, eof
         )
 
+    @tracer.start_as_current_span("upload_collector")
     def generate_upload_data(self, report_type="coverage") -> UploadCollectionResult:
         for prep in self.preparation_plugins:
             logger.debug(f"Running preparation plugin: {type(prep)}")
             prep.run_preparation(self)
         logger.debug("Collecting relevant files")
-        network = self.network_finder.find_files()
-        report_files = self.file_finder.find_files()
+        with tracer.start_as_current_span("file_collector"):
+            network = self.network_finder.find_files()
+            report_files = self.file_finder.find_files()
         logger.info(f"Found {len(report_files)} {report_type} files to report")
         if not report_files:
             if report_type == "test_results":

--- a/codecov_cli/services/upload/upload_sender.py
+++ b/codecov_cli/services/upload/upload_sender.py
@@ -5,6 +5,8 @@ import typing
 import zlib
 from typing import Any, Dict
 
+from opentelemetry import trace
+
 from codecov_cli import __version__ as codecov_cli_version
 from codecov_cli.helpers.config import CODECOV_INGEST_URL
 from codecov_cli.helpers.encoder import encode_slug
@@ -20,6 +22,7 @@ from codecov_cli.types import (
 )
 
 logger = logging.getLogger("codecovcli")
+tracer = trace.get_tracer(__name__)
 
 
 class UploadSender(object):
@@ -46,62 +49,75 @@ class UploadSender(object):
         upload_coverage: bool = False,
         args: dict = None,
     ) -> RequestResult:
-        data = {
-            "ci_service": ci_service,
-            "ci_url": build_url,
-            "cli_args": args,
-            "env": env_vars,
-            "flags": flags,
-            "job_code": job_code,
-            "name": name,
-            "version": codecov_cli_version,
-        }
-        if upload_coverage:
-            data["branch"] = branch
-            data["code"] = report_code
-            data["commitid"] = commit_sha
-            data["parent_commit_id"] = parent_sha
-            data["pullid"] = pull_request_number
-        headers = get_token_header(token)
-        encoded_slug = encode_slug(slug)
-        upload_url = enterprise_url or CODECOV_INGEST_URL
-        url, data = self.get_url_and_possibly_update_data(
-            data,
-            upload_file_type,
-            upload_url,
-            git_service,
-            branch,
-            encoded_slug,
-            commit_sha,
-            report_code,
-            upload_coverage,
-        )
-        # Data that goes to storage
-        reports_payload = self._generate_payload(
-            upload_data, env_vars, upload_file_type
-        )
+        with tracer.start_as_current_span("upload_sender") as span:
+            with tracer.start_as_current_span("upload_sender_preparation"):
+                data = {
+                    "ci_service": ci_service,
+                    "ci_url": build_url,
+                    "cli_args": args,
+                    "env": env_vars,
+                    "flags": flags,
+                    "job_code": job_code,
+                    "name": name,
+                    "version": codecov_cli_version,
+                }
+                if upload_coverage:
+                    data["branch"] = branch
+                    data["code"] = report_code
+                    data["commitid"] = commit_sha
+                    data["parent_commit_id"] = parent_sha
+                    data["pullid"] = pull_request_number
+                headers = get_token_header(token)
+                encoded_slug = encode_slug(slug)
+                upload_url = enterprise_url or CODECOV_INGEST_URL
+                url, data = self.get_url_and_possibly_update_data(
+                    data,
+                    upload_file_type,
+                    upload_url,
+                    git_service,
+                    branch,
+                    encoded_slug,
+                    commit_sha,
+                    report_code,
+                    upload_coverage,
+                )
+                # Data that goes to storage
+                reports_payload = self._generate_payload(
+                    upload_data, env_vars, upload_file_type
+                )
 
-        logger.debug("Sending upload request to Codecov")
-        resp_from_codecov = send_post_request(
-            url=url,
-            data=data,
-            headers=headers,
-        )
-        if resp_from_codecov.status_code >= 400:
-            return resp_from_codecov
-        resp_json_obj = json.loads(resp_from_codecov.text)
-        if resp_json_obj.get("url"):
-            logger.info(
-                f"Your upload is now processing. When finished, results will be available at: {resp_json_obj.get('url')}"
+            span.set_attributes(
+                {
+                    "commit_sha": commit_sha,
+                    "slug": slug,
+                }
             )
-        logger.debug(
-            "Upload request to Codecov complete.",
-            extra=dict(extra_log_attributes=dict(response=resp_json_obj)),
-        )
-        put_url = resp_json_obj["raw_upload_location"]
-        logger.debug("Sending upload to storage")
-        resp_from_storage = send_put_request(put_url, data=reports_payload)
-        return resp_from_storage
+
+            with tracer.start_as_current_span("upload_sender_storage_request"):
+                logger.debug("Sending upload request to Codecov")
+                resp_from_codecov = send_post_request(
+                    url=url,
+                    data=data,
+                    headers=headers,
+                )
+                if resp_from_codecov.status_code >= 400:
+                    return resp_from_codecov
+                resp_json_obj = json.loads(resp_from_codecov.text)
+                if resp_json_obj.get("url"):
+                    logger.info(
+                        f"Your upload is now processing. When finished, results will be available at: {resp_json_obj.get('url')}"
+                    )
+                logger.debug(
+                    "Upload request to Codecov complete.",
+                    extra=dict(extra_log_attributes=dict(response=resp_json_obj)),
+                )
+                put_url = resp_json_obj["raw_upload_location"]
+
+            with tracer.start_as_current_span("upload_sender_storage"):
+                logger.debug("Sending upload to storage")
+                resp_from_storage = send_put_request(put_url, data=reports_payload)
+
+            return resp_from_storage
 
     def _generate_payload(
         self,

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,29 +5,54 @@
 #    pip-compile setup.py
 #
 anyio==4.0.0
-    # via httpcore
+    # via httpx
 certifi==2023.7.22
     # via
     #   httpcore
     #   httpx
     #   requests
+    #   sentry-sdk
 charset-normalizer==3.3.0
     # via requests
 click==8.1.7
     # via codecov-cli (setup.py)
+deprecated==1.2.15
+    # via
+    #   opentelemetry-api
+    #   opentelemetry-semantic-conventions
 h11==0.14.0
     # via httpcore
-httpcore==0.16.3
+httpcore==1.0.7
     # via httpx
-httpx==0.23.3
+httpx==0.27.2
     # via codecov-cli (setup.py)
 idna==3.4
     # via
     #   anyio
+    #   httpx
     #   requests
-    #   rfc3986
 ijson==3.2.3
     # via codecov-cli (setup.py)
+importlib-metadata==8.5.0
+    # via opentelemetry-api
+opentelemetry-api==1.29.0
+    # via
+    #   opentelemetry-distro
+    #   opentelemetry-instrumentation
+    #   opentelemetry-sdk
+    #   opentelemetry-semantic-conventions
+opentelemetry-distro==0.50b0
+    # via sentry-sdk
+opentelemetry-instrumentation==0.50b0
+    # via opentelemetry-distro
+opentelemetry-sdk==1.29.0
+    # via opentelemetry-distro
+opentelemetry-semantic-conventions==0.50b0
+    # via
+    #   opentelemetry-instrumentation
+    #   opentelemetry-sdk
+packaging==24.2
+    # via opentelemetry-instrumentation
 pyyaml==6.0.1
     # via codecov-cli (setup.py)
 regex==2023.12.25
@@ -36,18 +61,26 @@ requests==2.31.0
     # via responses
 responses==0.21.0
     # via codecov-cli (setup.py)
-rfc3986[idna2008]==1.5.0
-    # via httpx
+sentry-sdk[opentelemetry]==2.19.2
+    # via codecov-cli (setup.py)
 sniffio==1.3.0
     # via
     #   anyio
-    #   httpcore
     #   httpx
 test-results-parser==0.5.1
     # via codecov-cli (setup.py)
 tree-sitter==0.20.2
     # via codecov-cli (setup.py)
+typing-extensions==4.12.2
+    # via opentelemetry-sdk
 urllib3==2.0.6
     # via
     #   requests
     #   responses
+    #   sentry-sdk
+wrapt==1.17.0
+    # via
+    #   deprecated
+    #   opentelemetry-instrumentation
+zipp==3.21.0
+    # via importlib-metadata

--- a/requirements.txt
+++ b/requirements.txt
@@ -78,7 +78,7 @@ urllib3==2.0.6
     #   requests
     #   responses
     #   sentry-sdk
-wrapt==1.16.0
+wrapt==1.17.1
     # via
     #   codecov-cli (setup.py)
     #   deprecated

--- a/requirements.txt
+++ b/requirements.txt
@@ -78,7 +78,7 @@ urllib3==2.0.6
     #   requests
     #   responses
     #   sentry-sdk
-wrapt==1.17.1
+wrapt==1.17.2
     # via
     #   codecov-cli (setup.py)
     #   deprecated

--- a/requirements.txt
+++ b/requirements.txt
@@ -61,7 +61,7 @@ requests==2.31.0
     # via responses
 responses==0.21.0
     # via codecov-cli (setup.py)
-sentry-sdk[opentelemetry]==2.19.2
+sentry-sdk[opentelemetry]==2.5.0
     # via codecov-cli (setup.py)
 sniffio==1.3.0
     # via
@@ -78,8 +78,9 @@ urllib3==2.0.6
     #   requests
     #   responses
     #   sentry-sdk
-wrapt==1.17.0
+wrapt==1.16.0
     # via
+    #   codecov-cli (setup.py)
     #   deprecated
     #   opentelemetry-instrumentation
 zipp==3.21.0

--- a/setup.py
+++ b/setup.py
@@ -27,6 +27,7 @@ setup(
         "test-results-parser==0.5.*",
         "regex",
         "sentry-sdk[opentelemetry]",
+        "wrapt==1.16.*",
     ],
     entry_points={
         "console_scripts": [

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ setup(
         "test-results-parser==0.5.*",
         "regex",
         "sentry-sdk[opentelemetry]",
-        "wrapt>=1.17.1",
+        "wrapt>=1.17.2",
     ],
     entry_points={
         "console_scripts": [

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ setup(
         "test-results-parser==0.5.*",
         "regex",
         "sentry-sdk[opentelemetry]",
-        "wrapt==1.16.*",
+        "wrapt>=1.17.1",
     ],
     entry_points={
         "console_scripts": [

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ setup(
             "codecovcli = codecov_cli.main:run",
         ],
     },
-    python_requires=">=3.8",
+    python_requires=">=3.9",
     ext_modules=[
         Extension(
             "staticcodecov_languages",

--- a/setup.py
+++ b/setup.py
@@ -26,6 +26,7 @@ setup(
         "tree-sitter==0.20.*",
         "test-results-parser==0.5.*",
         "regex",
+        "sentry-sdk[opentelemetry]",
     ],
     entry_points={
         "console_scripts": [


### PR DESCRIPTION
This also does a few other things:

1. Creates a `universal2` binary from our side to be compatible with `x86_64` and `arm64` macos builds
2. Removes `3.8` and adds `3.13` support