### PR TITLE
Fix crash with tuple concatenation onto list

### DIFF
--- a/codecov_cli/services/upload/file_finder.py
+++ b/codecov_cli/services/upload/file_finder.py
@@ -196,7 +196,7 @@ class FileFinder(object):
         report_type: str = "coverage",
     ):
         self.search_root = search_root or Path(os.getcwd())
-        self.folders_to_ignore = list(folders_to_ignore) or []
+        self.folders_to_ignore = list(folders_to_ignore) if folders_to_ignore else []
         self.explicitly_listed_files = explicitly_listed_files or None
         self.disable_search = disable_search
         self.report_type = report_type

--- a/codecov_cli/services/upload/file_finder.py
+++ b/codecov_cli/services/upload/file_finder.py
@@ -196,7 +196,7 @@ class FileFinder(object):
         report_type: str = "coverage",
     ):
         self.search_root = search_root or Path(os.getcwd())
-        self.folders_to_ignore = folders_to_ignore or []
+        self.folders_to_ignore = list(folders_to_ignore) or []
         self.explicitly_listed_files = explicitly_listed_files or None
         self.disable_search = disable_search
         self.report_type = report_type


### PR DESCRIPTION
Hey! I was trying to exclude files from my upload with `codecovcli -v upload-coverage -d --exclude tests` and I got the following error:

```py
Traceback (most recent call last):
  File "/home/tabulate/src/squiid-bindings/venv/bin/codecovcli", line 8, in <module>
    sys.exit(run())
             ~~~^^
  File "/home/tabulate/src/squiid-bindings/venv/lib/python3.13/site-packages/codecov_cli/main.py", line 93, in run
    cli(obj={})
    ~~~^^^^^^^^
  File "/home/tabulate/src/squiid-bindings/venv/lib/python3.13/site-packages/click/core.py", line 1161, in __call__
    return self.main(*args, **kwargs)
           ~~~~~~~~~^^^^^^^^^^^^^^^^^
  File "/home/tabulate/src/squiid-bindings/venv/lib/python3.13/site-packages/click/core.py", line 1082, in main
    rv = self.invoke(ctx)
  File "/home/tabulate/src/squiid-bindings/venv/lib/python3.13/site-packages/click/core.py", line 1697, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
                           ~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^
  File "/home/tabulate/src/squiid-bindings/venv/lib/python3.13/site-packages/click/core.py", line 1443, in invoke
    return ctx.invoke(self.callback, **ctx.params)
           ~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/tabulate/src/squiid-bindings/venv/lib/python3.13/site-packages/click/core.py", line 788, in invoke
    return __callback(*args, **kwargs)
  File "/home/tabulate/src/squiid-bindings/venv/lib/python3.13/site-packages/click/decorators.py", line 33, in new_func
    return f(get_current_context(), *args, **kwargs)
  File "/home/tabulate/src/squiid-bindings/venv/lib/python3.13/site-packages/codecov_cli/commands/upload_coverage.py", line 82, in upload_coverage
    ctx.invoke(
    ~~~~~~~~~~^
        upload_coverage_logic,
        ^^^^^^^^^^^^^^^^^^^^^^
    ...<37 lines>...
        args=args,
        ^^^^^^^^^^
    )
    ^
  File "/home/tabulate/src/squiid-bindings/venv/lib/python3.13/site-packages/click/core.py", line 788, in invoke
    return __callback(*args, **kwargs)
  File "/home/tabulate/src/squiid-bindings/venv/lib/python3.13/site-packages/codecov_cli/services/upload_coverage/__init__.py", line 50, in upload_coverage_logic
    return do_upload_logic(
        cli_config=cli_config,
    ...<37 lines>...
        upload_file_type=upload_file_type,
    )
  File "/home/tabulate/src/squiid-bindings/venv/lib/python3.13/site-packages/codecov_cli/services/upload/__init__.py", line 101, in do_upload_logic
    upload_data = collector.generate_upload_data(upload_file_type)
  File "/usr/lib/python3.13/contextlib.py", line 85, in inner
    return func(*args, **kwds)
  File "/home/tabulate/src/squiid-bindings/venv/lib/python3.13/site-packages/codecov_cli/services/upload/upload_collector.py", line 161, in generate_upload_data
    report_files = self.file_finder.find_files()
  File "/usr/lib/python3.13/contextlib.py", line 85, in inner
    return func(*args, **kwds)
  File "/home/tabulate/src/squiid-bindings/venv/lib/python3.13/site-packages/codecov_cli/services/upload/file_finder.py", line 224, in find_files
    default_folders_to_ignore + self.folders_to_ignore,
    ~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~
TypeError: can only concatenate list (not "tuple") to list
```

On further inspection, I'm guessing that click is producing a tuple instead of a list when creating the contents of the exclude argument. If you want this fix to be implemented further up the call chain, feel free to just close this PR, but I figured if this works then it took about 5 seconds to fix so I implemented it this way. This already has the error checking for if `folders_to_ignore` is `None` and I'm just casting the tuple to a list. 