### PR TITLE
Hide and mark ATS-related commands as deprecated

### DIFF
--- a/codecov_cli/commands/labelanalysis.py
+++ b/codecov_cli/commands/labelanalysis.py
@@ -23,7 +23,7 @@ from codecov_cli.types import CommandContext
 logger = logging.getLogger("codecovcli")
 
 
-@click.command()
+@click.command(hidden=True, deprecated=True)
 @click.option(
     "--token",
     required=True,
@@ -141,7 +141,9 @@ def label_analysis(
             logger.info(f"Collected {len(requested_labels)} test labels")
             logger.debug(
                 "Labels collected",
-                extra=dict(extra_log_attributes=dict(labels_collected=requested_labels)),
+                extra=dict(
+                    extra_log_attributes=dict(labels_collected=requested_labels)
+                ),
             )
             payload["requested_labels"] = requested_labels
 

--- a/codecov_cli/commands/staticanalysis.py
+++ b/codecov_cli/commands/staticanalysis.py
@@ -15,7 +15,7 @@ from codecov_cli.types import CommandContext
 logger = logging.getLogger("codecovcli")
 
 
-@click.command()
+@click.command(hidden=True, deprecated=True)
 @click.option(
     "--foldertosearch",
     default=".",

--- a/codecovcli_commands
+++ b/codecovcli_commands
@@ -17,11 +17,9 @@ Commands:
   do-upload
   empty-upload
   get-report-results
-  label-analysis
   pr-base-picking
   process-test-results
   send-notifications
-  static-analysis
   upload-coverage
   upload-process
 
@@ -179,28 +177,6 @@ Options:
                                   repo token in Self-hosted
   -h, --help                      Show this message and exit.
 
-Usage: codecovcli label-analysis [OPTIONS]
-
-Options:
-  --token TEXT                    The static analysis token (NOT the same
-                                  token as upload)  [required]
-  --head-sha TEXT                 Commit SHA (with 40 chars)  [required]
-  --base-sha TEXT                 Commit SHA (with 40 chars)  [required]
-  --runner-name, --runner TEXT    Runner to use
-  --max-wait-time INTEGER         Max time (in seconds) to wait for the label
-                                  analysis result before falling back to
-                                  running all tests. Default is to wait
-                                  forever.
-  --dry-run                       Print list of tests to run AND tests skipped
-                                  AND options that need to be added to the
-                                  test runner to stdout. Choose format with
-                                  --dry-run-format option. Default is JSON.
-  --dry-run-format [json|space-separated-list]
-                                  Format in which --dry-run data is printed.
-                                  Default is JSON.
-  --runner-param TEXT
-  -h, --help                      Show this message and exit.
-
 Usage: codecovcli pr-base-picking [OPTIONS]
 
 Options:
@@ -244,19 +220,6 @@ Options:
   -r, --slug TEXT                 owner/repo slug used instead of the private
                                   repo token in Self-hosted
   -h, --help                      Show this message and exit.
-
-Usage: codecovcli static-analysis [OPTIONS]
-
-Options:
-  --foldertosearch PATH      Folder to search
-  --numberprocesses INTEGER  number of processes to use
-  --pattern TEXT             file pattern to search for
-  --force / --no-force
-  --commit-sha TEXT          Commit SHA (with 40 chars)  [required]
-  --folders-to-exclude PATH  Folders not to search
-  --token TEXT               The static analysis token (NOT the same token as
-                             upload)  [required]
-  -h, --help                 Show this message and exit.
 
 Usage: codecovcli upload-coverage [OPTIONS]
 


### PR DESCRIPTION
As a first step, this just hides the commands from help output, and marks them as deprecated, which means invoking them outputs a message saying so.