### PR TITLE
fix typos discovered by codespell

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ Codecov-cli supports user input. These inputs, along with their descriptions and
 | `create-report-results` | Used for local upload. It tells codecov that you finished local uploading and want it to calculate the results for you to get them locally.
 | `get-report-results` | Used for local upload. It asks codecov to provide you the report results you calculated with the previous command.
 | `pr-base-picking` | Tells codecov that you want to explicitly define a base for your PR
-| `upload-process` | A wrapper for 3 commands. Create-commit, create-report and do-upload. You can use this command to upload to codecov instead of using the previosly mentioned commands.
+| `upload-process` | A wrapper for 3 commands. Create-commit, create-report and do-upload. You can use this command to upload to codecov instead of using the previously mentioned commands.
 | `send-notifications` | A command that tells Codecov that you finished uploading and you want to be sent notifications. To disable automatically sent notifications please consider adding manual_trigger to your codecov.yml, so it will look like codecov: notify: manual_trigger: true.
 >**Note**: Every command has its own different options that will be mentioned later in this doc. Codecov will try to load these options from your CI environment variables, if not, it will try to load them from git, if not found, you may need to add them manually.
 

--- a/codecov_cli/commands/labelanalysis.py
+++ b/codecov_cli/commands/labelanalysis.py
@@ -259,7 +259,7 @@ def _parse_runner_params(runner_params: List[str]) -> Dict[str, str]:
         # a good reason for the param to include '=' in the value.
         if param.count("=") == 0:
             logger.warning(
-                f"Runner param {param} is not well formated. Setting value to None. Use '--runner-param key=value' to set value"
+                f"Runner param {param} is not well formatted. Setting value to None. Use '--runner-param key=value' to set value"
             )
             final_params[param] = None
         else:

--- a/codecov_cli/plugins/pycoverage.py
+++ b/codecov_cli/plugins/pycoverage.py
@@ -28,7 +28,7 @@ class PycoverageConfig(dict):
     def report_type(self) -> str:
         """
         Report type to generate.
-        Overrided if include_contexts == True
+        Overridden if include_contexts == True
         report_type: str [values xml|json; default xml]
         """
         return self.get("report_type", "xml")

--- a/codecov_cli/runners/pytest_standard_runner.py
+++ b/codecov_cli/runners/pytest_standard_runner.py
@@ -76,7 +76,7 @@ class PytestStandardRunner(LabelAnalysisRunnerInterface):
         provided_config_params = config_params.keys()
         for provided_param in provided_config_params:
             if provided_param not in available_config_params:
-                logger.warning(f"Config parameter '{provided_param}' is unknonw.")
+                logger.warning(f"Config parameter '{provided_param}' is unknown.")
 
     def parse_captured_output_error(self, exp: CalledProcessError) -> str:
         result = ""

--- a/codecov_cli/services/report/__init__.py
+++ b/codecov_cli/services/report/__init__.py
@@ -138,7 +138,7 @@ def send_reports_result_get_request(
         state = response_content.get("state").lower()
         if state == "error":
             logger.error(
-                "An error occured while processing the report. Please try again later.",
+                "An error occurred while processing the report. Please try again later.",
                 extra=dict(
                     extra_log_attributes=dict(
                         response_status_code=response_obj.status_code,

--- a/codecov_cli/services/staticanalysis/__init__.py
+++ b/codecov_cli/services/staticanalysis/__init__.py
@@ -39,7 +39,7 @@ async def run_analysis_entrypoint(
     files = list(ff.find_files(folder, pattern, folders_to_exclude))
     processing_results = await process_files(files, numberprocesses, config)
     # Let users know if there were processing errors
-    # This is here and not in the funcition so we can add an option to ignore those (possibly)
+    # This is here and not in the function so we can add an option to ignore those (possibly)
     # Also makes the function easier to test
     processing_errors = processing_results["processing_errors"]
     log_processing_errors(processing_errors)

--- a/codecov_cli/services/staticanalysis/analyzers/python/node_wrappers.py
+++ b/codecov_cli/services/staticanalysis/analyzers/python/node_wrappers.py
@@ -16,7 +16,7 @@ class NodeVisitor(object):
             self.visit(c)
 
     def _is_function_docstring(self, node: Node):
-        """Skips docstrings for funtions, such as this one.
+        """Skips docstrings for functions, such as this one.
         Pytest doesn't include them in the report, so I don't think we should either,
         at least for now.
         """

--- a/tests/helpers/test_folder_searcher.py
+++ b/tests/helpers/test_folder_searcher.py
@@ -260,7 +260,7 @@ def test_search_directories(tmp_path):
     filename_include_regex = globs_to_regex(["*.app"])
     filepaths = [
         "banana.app/path/of/directory.txt",
-        "path/to/apple.app/path/of/directorys",
+        "path/to/apple.app/path/of/directories",
         "path/to/banana.app/folder/test.txt",
         "apple.py",
         "banana.py",

--- a/tests/helpers/test_versioning_systems.py
+++ b/tests/helpers/test_versioning_systems.py
@@ -105,7 +105,7 @@ class TestGitVersioningSystem(object):
             "codecov_cli.helpers.versioning_systems.subprocess.run",
             return_value=mocked_subprocess,
         )
-        # git ls-files diplays a single \n as \\\\n
+        # git ls-files displays a single \n as \\\\n
         mocked_subprocess.stdout = b'a.txt\nb.txt\n"a\\\\nb.txt"\nc.txt\nd.txt\n.circleci/config.yml\nLICENSE\napp/advanced calculations/advanced_calculator.js\n'
 
         vs = GitVersioningSystem()

--- a/tests/runners/test_pytest_standard_runner.py
+++ b/tests/runners/test_pytest_standard_runner.py
@@ -56,7 +56,7 @@ class TestPythonStandardRunner(object):
         runner = PytestStandardRunner(params)
         # Adding invalid config options emits a warning
         mock_warning.assert_called_with(
-            "Config parameter 'some_missing_option' is unknonw."
+            "Config parameter 'some_missing_option' is unknown."
         )
         # Warnings don't change the config
         assert runner.params == {**params, "some_missing_option": "option"}
@@ -91,7 +91,7 @@ class TestPythonStandardRunner(object):
                 cmd=command,
                 returncode=2,
                 output=b"Process running up to here...",
-                stderr=b"Some error occured",
+                stderr=b"Some error occurred",
             )
 
         mock_subprocess.run.side_effect = side_effect
@@ -100,7 +100,7 @@ class TestPythonStandardRunner(object):
             _ = self.runner._execute_pytest(["--option", "--ignore=batata"])
         assert (
             str(exp.value)
-            == "Pytest exited with non-zero code 2.\nThis is likely not a problem with label-analysis. Check pytest's output and options.\nPYTEST OUTPUT:\nProcess running up to here...\nSome error occured"
+            == "Pytest exited with non-zero code 2.\nThis is likely not a problem with label-analysis. Check pytest's output and options.\nPYTEST OUTPUT:\nProcess running up to here...\nSome error occurred"
         )
 
     @patch("codecov_cli.runners.pytest_standard_runner.subprocess")
@@ -112,7 +112,7 @@ class TestPythonStandardRunner(object):
             raise CalledProcessError(
                 cmd=command,
                 returncode=2,
-                stderr=b"Some error occured",
+                stderr=b"Some error occurred",
             )
 
         mock_subprocess.run.side_effect = side_effect
@@ -134,26 +134,26 @@ class TestPythonStandardRunner(object):
                     cmd=["python", "-m", "pytest", "missing_label"],
                     returncode=2,
                     output=b"Process running up to here...",
-                    stderr=b"Some error occured",
+                    stderr=b"Some error occurred",
                 ),
-                "\nProcess running up to here...\nSome error occured",
+                "\nProcess running up to here...\nSome error occurred",
             ),
             (
                 CalledProcessError(
                     cmd=["python", "-m", "pytest", "missing_label"],
                     returncode=2,
                     output="Process running up to here...",
-                    stderr="Some error occured",
+                    stderr="Some error occurred",
                 ),
-                "\nProcess running up to here...\nSome error occured",
+                "\nProcess running up to here...\nSome error occurred",
             ),
             (
                 CalledProcessError(
                     cmd=["python", "-m", "pytest", "missing_label"],
                     returncode=2,
-                    stderr=b"Some error occured",
+                    stderr=b"Some error occurred",
                 ),
-                "\nSome error occured",
+                "\nSome error occurred",
             ),
         ],
     )

--- a/tests/services/report/test_report_results.py
+++ b/tests/services/report/test_report_results.py
@@ -215,7 +215,7 @@ def test_get_report_results_200_error(mocker, capsys):
     mocked_response.assert_called_once()
     assert (
         "error",
-        'An error occured while processing the report. Please try again later. --- {"response_status_code": 200, "state": "error", "result": {}}',
+        'An error occurred while processing the report. Please try again later. --- {"response_status_code": 200, "state": "error", "result": {}}',
     ) in output
 
 

--- a/tests/services/static_analysis/test_static_analysis_service.py
+++ b/tests/services/static_analysis/test_static_analysis_service.py
@@ -286,7 +286,7 @@ class TestStaticAnalysisService:
 
         async def side_effect(presigned_put, data):
             if presigned_put == "http://storage-url-003":
-                raise httpx.HTTPError("Some error occured in the request")
+                raise httpx.HTTPError("Some error occurred in the request")
 
         mock_client.put.side_effect = side_effect
 


### PR DESCRIPTION
https://pypi.org/project/codespell

% `codespell`
```
./README.md:129: previosly ==> previously
./codecov_cli/plugins/pycoverage.py:31: Overrided ==> Overrode, Overridden
./codecov_cli/runners/pytest_standard_runner.py:79: unknonw ==> unknown
./codecov_cli/commands/labelanalysis.py:262: formated ==> formatted
./codecov_cli/services/staticanalysis/__init__.py:42: funcition ==> function
./codecov_cli/services/staticanalysis/analyzers/python/__init__.py:16: elemen ==> element
./codecov_cli/services/staticanalysis/analyzers/python/node_wrappers.py:19: funtions ==> functions
./codecov_cli/services/staticanalysis/analyzers/javascript_es6/__init__.py:12: elemen ==> element
./codecov_cli/services/staticanalysis/analyzers/javascript_es6/__init__.py:20: elemen ==> element
./codecov_cli/services/staticanalysis/analyzers/javascript_es6/__init__.py:24: elemen ==> element
./codecov_cli/services/staticanalysis/analyzers/javascript_es6/__init__.py:25: elemen ==> element
./codecov_cli/services/staticanalysis/analyzers/javascript_es6/__init__.py:29: elemen ==> element
./codecov_cli/services/report/__init__.py:141: occured ==> occurred
./tests/runners/test_pytest_standard_runner.py:59: unknonw ==> unknown
./tests/runners/test_pytest_standard_runner.py:94: occured ==> occurred
./tests/runners/test_pytest_standard_runner.py:103: occured ==> occurred
./tests/runners/test_pytest_standard_runner.py:115: occured ==> occurred
./tests/runners/test_pytest_standard_runner.py:137: occured ==> occurred
./tests/runners/test_pytest_standard_runner.py:139: occured ==> occurred
./tests/runners/test_pytest_standard_runner.py:146: occured ==> occurred
./tests/runners/test_pytest_standard_runner.py:148: occured ==> occurred
./tests/runners/test_pytest_standard_runner.py:154: occured ==> occurred
./tests/runners/test_pytest_standard_runner.py:156: occured ==> occurred
./tests/helpers/test_config.py:16: doesnt ==> doesn't, does not
./tests/helpers/test_folder_searcher.py:263: directorys ==> directories
./tests/helpers/test_versioning_systems.py:108: diplays ==> displays
./tests/services/static_analysis/test_static_analysis_service.py:289: occured ==> occurred
./tests/services/report/test_report_results.py:218: occured ==> occurred
./samples/inputs/sample_001.py:34: aks ==> ask
```
% `codespell --ignore-words-list=aks,doesnt,elemen --write-changes`