### PR TITLE
feat: Sample No junit xml reports found error

### DIFF
--- a/codecov-cli/codecov_cli/opentelemetry.py
+++ b/codecov-cli/codecov_cli/opentelemetry.py
@@ -7,6 +7,7 @@ from codecov_cli import __version__
 
 _SAMPLED_MESSAGES = [
     "Token required",
+    "No JUnit XML reports found",
 ]
 _SAMPLE_RATE = 100
 _SKIP_TAG_KEYS = {"branch", "flags", "commit_sha", "env_vars"}


### PR DESCRIPTION
Closes https://github.com/codecov/core-engineering/issues/72

- samples "No JUnit XML reports found" error to Sentry at a rate of 1%

This count of instances consistently rises with weekdays and falls with the weekend, indicating that this is probably a sampling of total traffic. We still want to be aware that this is happening but we don't need every single instance to be logged.