### PR TITLE
chore: Fix build_alpine uv install

### DIFF
--- a/scripts/build_alpine.sh
+++ b/scripts/build_alpine.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 set -eux
 apk add build-base python3 py3-pip curl
-python3 -m pip install --break-system-packages uv
+python3 -m pip install uv --only-binary uv
 # Need to build with python 3.9 to support systems with libpython >= 3.9
 uv python pin 3.9
 uv sync --no-binary-package pyyaml --no-binary-package ijson


### PR DESCRIPTION
Fixing broken CI alpine build. Alpine 3.14 ships with pip 20.3.4 which is too old to recognize the `break-system-packages` flag.
<img width="326" height="286" alt="Screenshot 2026-07-06 at 12 38 29 PM" src="https://github.com/user-attachments/assets/251f0655-cc09-4de8-9d9c-1a850a0bcabd" />
