### PR TITLE
fix: grant contents:write to release flow buildassets job

### DIFF
--- a/.github/workflows/release_flow.yml
+++ b/.github/workflows/release_flow.yml
@@ -21,6 +21,8 @@ jobs:
 
   buildassets:
     name: Build packages
+    permissions:
+      contents: write # required so the reusable workflow can attach release assets
     uses: ./.github/workflows/build_assets.yml
     with:
       release: true


### PR DESCRIPTION
## Summary
- The `Build and Publish CLI Release` workflow (`release_flow.yml`) failed with `startup_failure` (e.g. [run 28972104407](https://github.com/codecov/codecov-cli/actions/runs/28972104407)).
- Root cause: commit `987d53c` bumped `build_assets.yml`'s workflow-level permission to `contents: write` (needed so `upload-release-action` can attach release assets via `GITHUB_TOKEN`). A reusable workflow cannot request more permission than the caller grants, but `release_flow.yml` calls it from the `buildassets` job with only the default `contents: read`, so the workflow failed to compile and no jobs ran.
- Fix: grant `contents: write` on the `buildassets` job so the reusable workflow can compile and successfully upload assets.

## Test plan
- [ ] Merge to `main`, then re-cut the `v11.3.0` release/tag so GitHub loads the corrected workflow files for the `release: created` event.
- [ ] Confirm the `Build and Publish CLI Release` run starts (no `startup_failure`) and the `buildassets` job uploads release assets.

Made with [Cursor](https://cursor.com)