### PR TITLE
fix: allow empty commit when preparing release PR

### DIFF
--- a/.github/workflows/create_release_pr.yml
+++ b/.github/workflows/create_release_pr.yml
@@ -37,7 +37,7 @@ jobs:
         run: |
           sed -i 's/version\ =\ "[0-9]\+\.[0-9]\+\.[0-9]\+"/version\ =\ "${{ github.event.inputs.versionName }}"/g' pyproject.toml
           git add pyproject.toml
-          git commit -S --message "Prepare release ${{ github.event.inputs.versionName }}"
+          git commit -S --allow-empty --message "Prepare release ${{ github.event.inputs.versionName }}"
           echo "commit=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
           git push origin release/${{ github.event.inputs.versionName }}
 


### PR DESCRIPTION
## Summary
- The `Create CLI Release PR` workflow failed with `nothing to commit, working tree clean` (e.g. [run 28972926678](https://github.com/codecov/codecov-cli/actions/runs/28972926678/job/85972891735)) when the version in `pyproject.toml` already matched the requested release version, so `sed` produced no diff and `git commit` exited non-zero.
- Add `--allow-empty` to the release commit so the release branch and PR are still created even when there is no version change.

## Test plan
- [ ] Run the `Create CLI Release PR` workflow with a version that already matches `pyproject.toml` and confirm the branch/PR is created with an (empty) signed commit.

Made with [Cursor](https://cursor.com)