### PR TITLE
fix: upgrade pip before installing uv in alpine build

### DIFF
--- a/scripts/build_alpine.sh
+++ b/scripts/build_alpine.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 set -eux
 apk add build-base python3 py3-pip curl
-python3 -m pip install uv --only-binary uv
+curl -LsSf https://astral.sh/uv/install.sh | env UV_INSTALL_DIR=/usr/local/bin sh
 # Need to build with python 3.9 to support systems with libpython >= 3.9
 uv python pin 3.9
 uv sync --no-binary-package pyyaml --no-binary-package ijson

--- a/scripts/build_alpine.sh
+++ b/scripts/build_alpine.sh
@@ -1,7 +1,8 @@
 #!/bin/sh
 set -eux
 apk add build-base python3 py3-pip curl
-curl -LsSf https://astral.sh/uv/install.sh | env UV_INSTALL_DIR=/usr/local/bin sh
+python3 -m pip install --upgrade pip
+python3 -m pip install uv --only-binary uv
 # Need to build with python 3.9 to support systems with libpython >= 3.9
 uv python pin 3.9
 uv sync --no-binary-package pyyaml --no-binary-package ijson


### PR DESCRIPTION
## Summary
- The `Build and Publish CLI Release` Alpine matrix legs failed at `Run in Docker` (e.g. [run 28973879139](https://github.com/codecov/codecov-cli/actions/runs/28973879139/job/85976084061)) with `ERROR: No matching distribution found for uv`.
- Root cause: `alpine:3.14` ships system pip `20.3.4`, which predates `musllinux` wheel-tag support (PEP 656, added in pip 21.3). Since `uv` only ships musl builds as `musllinux` wheels, `pip install uv --only-binary uv` finds no compatible candidate and fails.
- Fix: upgrade pip first so it recognizes `musllinux` tags and can install the `uv` wheel. Alpine 3.14 has no PEP 668 `EXTERNALLY-MANAGED` marker (that arrived in Alpine 3.19 / Python 3.11), so no `--break-system-packages` is required. `--only-binary uv` is kept so pip never falls back to a source build.

## Test plan
- [ ] Re-run the release (or the `build_assets` workflow with `release: true`) and confirm the Alpine x86_64 and arm64 legs build and upload assets successfully.